### PR TITLE
Fix broken example with `sequence` attribute to `index`.

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -1333,20 +1333,23 @@ conflicting definitions.
 <div class="example">
 ```xml
 <global parts="p1 p2">
-  <measure>
+  <measure index="1">
     <directions>
       <time signature="6/8"/>
     </directions>
   </measure>
-  <measure sequence="4" barline="final"/>
+  <measure index="2"/>
+  <measure index="3"/>
+  <measure index="4" barline="final"/>
 </global>
 <global parts="p3 p4">
-  <measure>
+  <measure index="1">
     <directions>
       <time signature="4/4"/>
     </directions>
   </measure>
-  <measure sequence="3" barline="final"/>
+  <measure index="2"/>
+  <measure index="3" barline="final"/>
 </global>
 <part id="p1">...</part>
 <part id="p2">...</part>


### PR DESCRIPTION
Addresses broken example relating to issue #2.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/pull/91.html" title="Last updated on Mar 21, 2018, 4:37 PM GMT (6a691a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/91/2dc196f...6a691a5.html" title="Last updated on Mar 21, 2018, 4:37 PM GMT (6a691a5)">Diff</a>