### PR TITLE
Supply attributes controlling tuplet decorations.

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -1925,6 +1925,9 @@ keyboard voice that temporarily crosses into the upper staff:
     <dd><{tuplet/inner}> - duration of the enclosed sequence content</dd>
     <dd><{sequence/orient}> - optional <a>orientation</a> of this tuplet </dd>
     <dd><{sequence/staff}> - optional <a>staff index</a> of this tuplet </dd>
+    <dd><{tuplet/show-number}> - optional control over the display of the tuplet ratio numbers</dd>
+    <dd><{tuplet/show-value}> - optional control over the display of the tuplet ratio note values</dd>
+    <dd><{tuplet/bracket}> - optional control over the display of brackets</dd>
   </dl>
 
 The <{tuplet}> element organizes a set of musical events that form a distinct
@@ -1957,6 +1960,46 @@ The <dfn element-attr>staff</dfn> attribute provides a specific
 <a>staff index</a> for all content within this tuplet.  If not provided, the
 staff index is determined automatically according to the implementation's
 rendering rules.
+
+The optional <dfn element-attr>show-number</dfn> attribute controls the display
+of the quantity of inner and outer note value units for the tuplet. Permissible values
+include:
+
+<dl dfn-for="tuplet/show-number">
+  <dt><dfn attr-value><code>none</code></dfn></dt>
+  <dd>Do not show any tuplet number.</dd>
+  <dt><dfn attr-value><code>inner</code></dfn> (default)</dt>
+  <dd>Display only the numerator of the tuplet's <{tuplet/inner}> attribute.</dd>
+  <dt><dfn attr-value><code>both</code></dfn></dt>
+  <dd>Display the numerators of the tuplet's <{tuplet/inner}> and <{tuplet/outer}> attributes.</dd>
+</dl>
+
+The optional <dfn element-attr>show-value</dfn> attribute controls the display
+of the note value units used inside and outside the tuplet. Permissible values
+include:
+
+<dl dfn-for="tuplet/show-value">
+  <dt><dfn attr-value><code>none</code></dfn> (default)</dt>
+  <dd>Do not show any tuplet units.</dd>
+  <dt><dfn attr-value><code>inner</code></dfn></dt>
+  <dd>Display only the note value unit of the tuplet's <{tuplet/inner}> attribute.</dd>
+  <dt><dfn attr-value><code>both</code></dfn></dt>
+  <dd>Display both the note value units of the tuplet's <{tuplet/inner}> and <{tuplet/outer}> attributes.</dd>
+</dl>
+
+The optional <dfn element-attr>bracket</dfn> attribute controls the display of
+a bracket in conjunction with the tuplet. 
+It is disregarded if <{tuplet/show-number}> has a value of <{tuplet/show-number/none}>.
+Values include:
+
+<dl dfn-for="tuplet/bracket">
+  <dt><dfn attr-value><code>auto</code></dfn> (default)</dt>
+  <dd>A bracket is shown for the tuplet if and only if the notes are unbeamed.</dd>
+  <dt><dfn attr-value><code>no</code></dfn></dt>
+  <dd>Do not display a bracket.</dd>
+  <dt><dfn attr-value><code>yes</code></dfn></dt>
+  <dd>Always display a bracket.</dd>
+</dl>
 
 <div class="example">
 ```xml


### PR DESCRIPTION
Fixes #127. The approach is to use attributes rather than styles, as tuplet decorations border on the semantic.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/pull/128.html" title="Last updated on May 18, 2018, 8:53 PM GMT (3652d9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/128/a7fd706...3652d9a.html" title="Last updated on May 18, 2018, 8:53 PM GMT (3652d9a)">Diff</a>