### PR TITLE
Clarify whether 8va affects definition of 'written pitch'

### DIFF
--- a/specification/index.bs
+++ b/specification/index.bs
@@ -979,9 +979,12 @@ the pitch that an instrument generates.
 A note's written pitch differs from its sounded pitch in case of a
 part written for a transposing instrument, such as a clarinet.
 
-<em>Needs clarity about how 8va markings are taken into account. Is the
-written pitch the literal pitch that's printed on the page, or is it the
-pitch that the musician is "thinking of" (after applying the 8va)?</em>
+MNX considers ottava markings (e.g., "8va," "8vb") to be purely
+presentational. Hence, ottava markings have no effect on a note's
+written pitch. For example, if a note is rendered on the bottom
+staff line without an ottava marking, and a second note is
+rendered on the top staff space with an "8vb" marking, the two
+notes have the same written pitch.
 
 <h4 id="common-notational-syntaxes">Notational syntaxes</h4>
 

--- a/specification/index.bs
+++ b/specification/index.bs
@@ -972,12 +972,15 @@ and articulations accordingly.</li>
 
 <h5 id="written-pitch">Written pitch</h5>
 
-A note's <dfn>written pitch</dfn> is the pitch that is rendered in
-notation. This might be different from its sounded pitch, which is
-the pitch that an instrument generates.
+A note's <dfn>written pitch</dfn> is the pitch that would sound
+if the note's notation were performed by a concert-pitch instrument.
+Written pitch can be thought of as the note's pitch from the
+musician's instrument-specific perspective.
 
-A note's written pitch differs from its sounded pitch in case of a
-part written for a transposing instrument, such as a clarinet.
+A note's written pitch might be different from its sounded pitch,
+which is the pitch that an instrument generates. Written pitch
+differs from sounded pitch in case of notation written for a
+transposing instrument, such as a clarinet.
 
 MNX considers ottava markings (e.g., "8va," "8vb") to be purely
 presentational. Hence, ottava markings have no effect on a note's


### PR DESCRIPTION
This pull request ties up a loose end from commit cf46aa48a2f1ce21df5f4f4cac4d37b6f3757ea5 — which defined "written pitch" but didn't specify how/whether ottava markings affect the written pitch from MNX-Common's perspective.

This change to the spec uses the same approach as MusicXML, which is that ottava markings are considered presentational and don't affect the "written pitch." Here's some relevant thinking from Michael Good (via email), musing on MusicXML's experience:

> In MusicXML, the <pitch> element represents is the semantic concept of pitch for someone reading the music, not a graphic representation of where the pitch happens to be notated on the staff. There is no transformation required for accidentals present in key signatures (those alterations have to be included in the pitch even if no accidental is displayed), octave lines, or octave-transposing clefs. The only transformation needed comes from data in the <transpose> element.
>
>This part of MusicXML has seemed to work really well, so I believe it should be maintained for MNX-Common.

I'd like to get two bits of feedback on this:

1. Is there any opposition to the treatment of ottavas as presentation (i.e., not affecting written pitch)?
2. Is the specific wording clear and unambiguous enough?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/pull/152.html" title="Last updated on May 2, 2019, 9:43 AM UTC (c1dacbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/152/cf46aa4...c1dacbf.html" title="Last updated on May 2, 2019, 9:43 AM UTC (c1dacbf)">Diff</a>