### PR TITLE
Make <head> optional

### DIFF
--- a/specification/common/index.bs
+++ b/specification/common/index.bs
@@ -1036,7 +1036,7 @@ a <a>SMuFL glyph name</a> from the catalog of glyph names defined in the
     <dt><a>Contexts</a>:</dt>
     <dd>None: this is the top-level element.</dd>
     <dt><a>Content Model</a>:</dt>
-    <dd>A single, required <{head}> element.</dd>
+    <dd>A single, optional <{head}> element.</dd>
     <dd>Either a <{collection}> or a <{score}> element.</dd>
     <dt><a>Attributes</a>:</dt>
     <dd>None.</dd>


### PR DESCRIPTION
This pull request addresses issue #166 — making the `<head>` element optional.

It's just a tiny change to the spec!

No changes were necessary to the MNX-Common By Example page, because none of those examples were using `<head>`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/pull/170.html" title="Last updated on Nov 12, 2019, 12:56 PM UTC (e3bc638)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/170/4b6701a...e3bc638.html" title="Last updated on Nov 12, 2019, 12:56 PM UTC (e3bc638)">Diff</a>