### PR TITLE
Specify barline defaults

### DIFF
--- a/by-example/index.html
+++ b/by-example/index.html
@@ -123,10 +123,10 @@ a {
 
     <p><strong>IMPORTANT NOTE: The MNX-Common spec is not yet ready for implementation.</strong> MNX-Common is still a work in progress, and we hope you’ll get involved with its development. Does anything look weird in these examples? Hard to parse? Confusing? Potentially ambiguous? We want to hear about it. Make sure you’ve joined the <a href="https://www.w3.org/community/music-notation/">W3C Music Notation Community Group</a>, and post your ideas to <a href="https://github.com/w3c/mnx/issues">our GitHub issue tracker</a>.</p>
 
-    <p>Some notes about these examples:</p>
+    <p>Some notes about these MNX-Common examples:</p>
     <ul>
         <li>Note stem directions are generally not encoded in these examples, for brevity. This means the consuming program decides which stem direction to use.</li>
-        <li>Barlines are generally not encoded in these examples. <a href="https://github.com/w3c/mnx/issues/165">We’re currently deciding</a> whether to make them opt-in or opt-out.</li>
+        <li>Barlines are generally not encoded here. In MNX-Common, a “standard” barline is assumed to exist at the end of each measure, and a “final” barline is assumed to exist at the end of the last measure in the document. Thus, you only need to encode barlines if they differ from these assumed defaults.</li>
     </ul>
 </section>
 

--- a/by-example/index.html
+++ b/by-example/index.html
@@ -126,7 +126,7 @@ a {
     <p>Some notes about these MNX-Common examples:</p>
     <ul>
         <li>Note stem directions are generally not encoded in these examples, for brevity. This means the consuming program decides which stem direction to use.</li>
-        <li>Barlines are generally not encoded here. In MNX-Common, a “standard” barline is assumed to exist at the end of each measure, and a “final” barline is assumed to exist at the end of the last measure in the document. Thus, you only need to encode barlines if they differ from these assumed defaults.</li>
+        <li>Barlines are generally not encoded here. In MNX-Common, a standard barline is assumed to exist at the end of each measure, and a final barline is assumed to exist at the end of the last measure in the document. Thus, you only need to encode barlines if they differ from these assumed defaults.</li>
     </ul>
 </section>
 

--- a/by-example/index.html
+++ b/by-example/index.html
@@ -186,7 +186,7 @@ a {
             &lt;/global&gt;
             &lt;part&gt;
                 &lt;part-name&gt;Music&lt;/part-name&gt;
-                &lt;measure&gt;
+                &lt;measure barline="regular"&gt;
                     &lt;sequence&gt;
                         &lt;directions&gt;
                             &lt;clef sign="G" line="2"/&gt;
@@ -339,7 +339,7 @@ a {
                         &lt;/event&gt;
                     &lt;/sequence&gt;
                 &lt;/measure&gt;
-                &lt;measure&gt;
+                &lt;measure barline="regular"&gt;
                     &lt;sequence&gt;
                         &lt;event value="/4"&gt;
                             &lt;note pitch="G4"/&gt;
@@ -447,7 +447,7 @@ a {
             &lt;/global&gt;
             &lt;part&gt;
                 &lt;part-name&gt;Music&lt;/part-name&gt;
-                &lt;measure&gt;
+                &lt;measure barline="regular"&gt;
                     &lt;sequence&gt;
                         &lt;directions&gt;
                             &lt;clef sign="G" line="2"/&gt;
@@ -649,7 +649,7 @@ a {
                         &lt;/event&gt;
                     &lt;/sequence&gt;
                 &lt;/measure&gt;
-                &lt;measure&gt;
+                &lt;measure barline="regular"&gt;
                     &lt;sequence&gt;
                         &lt;event value="/1"&gt;
                             &lt;note pitch="C4"/&gt;

--- a/specification/common/index.bs
+++ b/specification/common/index.bs
@@ -1267,7 +1267,7 @@ tempo indications.
   </measure>
   <measure index="2"/>
   <measure index="3"/>
-  <measure index="4" barline="final"/>
+  <measure index="4"/>
 </global>
 ```
 </div>
@@ -1295,7 +1295,7 @@ conflicting definitions.
   </measure>
   <measure index="2"/>
   <measure index="3"/>
-  <measure index="4" barline="final"/>
+  <measure index="4"/>
 </global>
 <global parts="p3 p4">
   <measure index="1">
@@ -1304,7 +1304,7 @@ conflicting definitions.
     </directions>
   </measure>
   <measure index="2"/>
-  <measure index="3" barline="final"/>
+  <measure index="3"/>
 </global>
 <part id="p1">...</part>
 <part id="p2">...</part>
@@ -1414,6 +1414,11 @@ for the barline drawn at the end of the measure. Allowed values include:
   <dd><dfn attr-value>short</dfn></dd>
   <dd><dfn attr-value>none</dfn></dd>
 </dl>
+
+If <{barline}> is not given, then the barline should be interpreted as follows:
+
+  1. If the measure is the last in the document, use <{light-heavy}>.
+  2. Otherwise, use <{regular}>.
 
 The following example shows both direction content and a single-voice sequence
 with two monophonic half notes:


### PR DESCRIPTION
This updates the MNX-Common spec to give the defaults for barlines.

It also updates the MNX-Common By Example page to make the markup examples match the screenshots, with respect to the final barline. (Some examples use a proper final barline, while others use a "normal" barline.)

This addresses issue #165.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/pull/171.html" title="Last updated on Nov 14, 2019, 2:18 PM UTC (03866ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/171/4b6701a...03866ae.html" title="Last updated on Nov 14, 2019, 2:18 PM UTC (03866ae)">Diff</a>