### PR TITLE
Complete the renaming of MNX-Common to MNX (Part 1)

### DIFF
--- a/by-example/index.html
+++ b/by-example/index.html
@@ -100,30 +100,26 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure barline="regular">
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C4"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure barline="regular">
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C4"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -236,56 +232,52 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="F4"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure barline="regular">
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="G4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="A4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="B4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="F4"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure barline="regular">
+            <sequence>
+                <event value="/4">
+                    <note pitch="G4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="A4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="B4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -368,35 +360,31 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure barline="regular">
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-</script><script type="application/xml" class="markupxml diff">                        <event value="/2">
-                            <note pitch="C4"/>
-                            <note pitch="E4"/>
-                            <note pitch="G4"/>
-                        </event>
-                        <event value="/2">
-                            <rest/>
-                        </event>
-</script><script type="application/xml" class="markupxml nodiff">                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure barline="regular">
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+</script><script type="application/xml" class="markupxml diff">                <event value="/2">
+                    <note pitch="C4"/>
+                    <note pitch="E4"/>
+                    <note pitch="G4"/>
+                </event>
+                <event value="/2">
+                    <rest/>
+                </event>
+</script><script type="application/xml" class="markupxml nodiff">            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -538,71 +526,67 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-</script><script type="application/xml" class="markupxml diff">            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-                <measure>
-                    <directions>
-                        <time signature="2/4"/>
-                    </directions>
-                </measure>
-            </global>
-</script><script type="application/xml" class="markupxml nodiff">            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="F5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="F5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="B4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+</script><script type="application/xml" class="markupxml diff">    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+        <measure>
+            <directions>
+                <time signature="2/4"/>
+            </directions>
+        </measure>
+    </global>
+</script><script type="application/xml" class="markupxml nodiff">    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="F5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="F5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/4">
+                    <note pitch="B4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -751,77 +735,73 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-</script><script type="application/xml" class="markupxml diff">                        <key fifths="4"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure/>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <key fifths="-4"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="F#5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="G#5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="G#5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="Ab4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="Bb4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="Ab4"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+</script><script type="application/xml" class="markupxml diff">                <key fifths="4"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure/>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <key fifths="-4"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="F#5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="G#5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="G#5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/4">
+                    <note pitch="Ab4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="Bb4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="Ab4"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -951,62 +931,58 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                        <key fifths="-2"/>
-                    </directions>
-                </measure>
-                <measure/>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="F4"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="G4"/>
-                        </event>
-                        <event value="/4">
-</script><script type="application/xml" class="markupxml diff">                            <note pitch="G#4" accidental="sharp"/>
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                        <event value="/4">
-                            <note pitch="A4"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="Bb4"/>
-                        </event>
-                        <event value="/4">
-</script><script type="application/xml" class="markupxml diff">                            <note pitch="Db5" accidental="flat"/>
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                        <event value="/4">
-                            <note pitch="Db5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-</script><script type="application/xml" class="markupxml diff">                            <note pitch="D5" accidental="natural"/>
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+                <key fifths="-2"/>
+            </directions>
+        </measure>
+        <measure/>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="F4"/>
+                </event>
+                <event value="/4">
+                    <note pitch="G4"/>
+                </event>
+                <event value="/4">
+</script><script type="application/xml" class="markupxml diff">                    <note pitch="G#4" accidental="sharp"/>
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+                <event value="/4">
+                    <note pitch="A4"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2">
+                    <note pitch="Bb4"/>
+                </event>
+                <event value="/4">
+</script><script type="application/xml" class="markupxml diff">                    <note pitch="Db5" accidental="flat"/>
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+                <event value="/4">
+                    <note pitch="Db5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+</script><script type="application/xml" class="markupxml diff">                    <note pitch="D5" accidental="natural"/>
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -1113,41 +1089,37 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-</script><script type="application/xml" class="markupxml diff">                        <event value="/4d">
-</script><script type="application/xml" class="markupxml nodiff">                            <note pitch="G4"/>
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/8">
-                            <note pitch="E5"/>
-                        </event>
-</script><script type="application/xml" class="markupxml diff">                        <event value="/4d">
-</script><script type="application/xml" class="markupxml nodiff">                            <note pitch="F4"/>
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/8">
-                            <note pitch="F5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+</script><script type="application/xml" class="markupxml diff">                <event value="/4d">
+</script><script type="application/xml" class="markupxml nodiff">                    <note pitch="G4"/>
+                    <note pitch="C5"/>
+                </event>
+                <event value="/8">
+                    <note pitch="E5"/>
+                </event>
+</script><script type="application/xml" class="markupxml diff">                <event value="/4d">
+</script><script type="application/xml" class="markupxml nodiff">                    <note pitch="F4"/>
+                    <note pitch="D5"/>
+                </event>
+                <event value="/8">
+                    <note pitch="F5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -1273,56 +1245,52 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5">
-</script><script type="application/xml" class="markupxml diff">                                <tied target="note3"/>
-</script><script type="application/xml" class="markupxml nodiff">                            </note>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5" id="note3"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C5">
-</script><script type="application/xml" class="markupxml diff">                                <tied target="note5"/>
-</script><script type="application/xml" class="markupxml nodiff">                            </note>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="C5" id="note5">
-</script><script type="application/xml" class="markupxml diff">                                <tied target="note6"/>
-</script><script type="application/xml" class="markupxml nodiff">                            </note>
-                        </event>
-                        <event value="/2">
-                            <note pitch="C5" id="note6"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5">
+</script><script type="application/xml" class="markupxml diff">                        <tied target="note3"/>
+</script><script type="application/xml" class="markupxml nodiff">                    </note>
+                </event>
+                <event value="/4">
+                    <note pitch="E5" id="note3"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C5">
+</script><script type="application/xml" class="markupxml diff">                        <tied target="note5"/>
+</script><script type="application/xml" class="markupxml nodiff">                    </note>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2">
+                    <note pitch="C5" id="note5">
+</script><script type="application/xml" class="markupxml diff">                        <tied target="note6"/>
+</script><script type="application/xml" class="markupxml nodiff">                    </note>
+                </event>
+                <event value="/2">
+                    <note pitch="C5" id="note6"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -1549,77 +1517,73 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-</script><script type="application/xml" class="markupxml diff">                        <tuplet inner="3/8" outer="2/8">
-</script><script type="application/xml" class="markupxml nodiff">                            <event value="/4">
-                                <note pitch="C5"/>
-                            </event>
-                            <event value="/8">
-                                <note pitch="G4"/>
-                            </event>
-</script><script type="application/xml" class="markupxml diff">                        </tuplet>
-                        <tuplet inner="3/8" outer="2/8">
-</script><script type="application/xml" class="markupxml nodiff">                            <event value="/8">
-                                <note pitch="E4"/>
-                            </event>
-                            <event value="/8">
-                                <note pitch="F4"/>
-                            </event>
-                            <event value="/8">
-                                <note pitch="G4"/>
-                            </event>
-</script><script type="application/xml" class="markupxml diff">                        </tuplet>
-</script><script type="application/xml" class="markupxml nodiff">                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-</script><script type="application/xml" class="markupxml diff">                        <tuplet inner="6/4" outer="4/4">
-</script><script type="application/xml" class="markupxml nodiff">                            <event value="/4">
-                                <note pitch="C5"/>
-                            </event>
-                            <event value="/4">
-                                <note pitch="D5"/>
-                            </event>
-                            <event value="/4">
-                                <note pitch="C5"/>
-                            </event>
-                            <event value="/4">
-                                <note pitch="G4"/>
-                            </event>
-                            <event value="/4">
-                                <note pitch="E5"/>
-                            </event>
-                            <event value="/4">
-                                <note pitch="C5"/>
-                            </event>
-</script><script type="application/xml" class="markupxml diff">                        </tuplet>
-</script><script type="application/xml" class="markupxml nodiff">                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+</script><script type="application/xml" class="markupxml diff">                <tuplet inner="3/8" outer="2/8">
+</script><script type="application/xml" class="markupxml nodiff">                    <event value="/4">
+                        <note pitch="C5"/>
+                    </event>
+                    <event value="/8">
+                        <note pitch="G4"/>
+                    </event>
+</script><script type="application/xml" class="markupxml diff">                </tuplet>
+                <tuplet inner="3/8" outer="2/8">
+</script><script type="application/xml" class="markupxml nodiff">                    <event value="/8">
+                        <note pitch="E4"/>
+                    </event>
+                    <event value="/8">
+                        <note pitch="F4"/>
+                    </event>
+                    <event value="/8">
+                        <note pitch="G4"/>
+                    </event>
+</script><script type="application/xml" class="markupxml diff">                </tuplet>
+</script><script type="application/xml" class="markupxml nodiff">                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+</script><script type="application/xml" class="markupxml diff">                <tuplet inner="6/4" outer="4/4">
+</script><script type="application/xml" class="markupxml nodiff">                    <event value="/4">
+                        <note pitch="C5"/>
+                    </event>
+                    <event value="/4">
+                        <note pitch="D5"/>
+                    </event>
+                    <event value="/4">
+                        <note pitch="C5"/>
+                    </event>
+                    <event value="/4">
+                        <note pitch="G4"/>
+                    </event>
+                    <event value="/4">
+                        <note pitch="E5"/>
+                    </event>
+                    <event value="/4">
+                        <note pitch="C5"/>
+                    </event>
+</script><script type="application/xml" class="markupxml diff">                </tuplet>
+</script><script type="application/xml" class="markupxml nodiff">            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -1769,66 +1733,62 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-</script><script type="application/xml" class="markupxml diff">                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="C4"/>
-                        </event>
-                        <event value="/2">
-                            <note pitch="G3"/>
-                        </event>
-                    </sequence>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="F5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="G5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="B4"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C4"/>
-                        </event>
-                    </sequence>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/2">
-                            <note pitch="C6"/>
-                        </event>
-                    </sequence>
-                </measure>
-</script><script type="application/xml" class="markupxml nodiff">            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+</script><script type="application/xml" class="markupxml diff">        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/2">
+                    <note pitch="C4"/>
+                </event>
+                <event value="/2">
+                    <note pitch="G3"/>
+                </event>
+            </sequence>
+            <sequence>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="F5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="G5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="B4"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C4"/>
+                </event>
+            </sequence>
+            <sequence>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/2">
+                    <note pitch="C6"/>
+                </event>
+            </sequence>
+        </measure>
+</script><script type="application/xml" class="markupxml nodiff">    </part>
 </mnx></script>
             </div>
         </div>
@@ -1942,53 +1902,49 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-</script><script type="application/xml" class="markupxml diff">                        <directions>
-                            <octave-shift type="-8" end="2:1/2" />
-                        </directions>
-</script><script type="application/xml" class="markupxml nodiff">                        <event value="/2">
-                            <note pitch="C7"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="E7"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C7"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C6"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+</script><script type="application/xml" class="markupxml diff">                <directions>
+                    <octave-shift type="-8" end="2:1/2" />
+                </directions>
+</script><script type="application/xml" class="markupxml nodiff">                <event value="/2">
+                    <note pitch="C7"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2">
+                    <note pitch="E7"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C7"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C6"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -2119,58 +2075,54 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4" id="event1">
-                            <note pitch="C5"/>
-</script><script type="application/xml" class="markupxml diff">                            <slur side="up" target="event4" />
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                        <event value="/4" id="event2">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/4" id="event3">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4" id="event4">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/4" id="event5">
-                            <note pitch="G4"/>
-</script><script type="application/xml" class="markupxml diff">                            <slur side="down" target="event8" />
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                        <event value="/4" id="event6">
-                            <note pitch="A4"/>
-                        </event>
-                        <event value="/4" id="event7">
-                            <note pitch="G4"/>
-                        </event>
-                        <event value="/4" id="event8">
-                            <note pitch="E4"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4" id="event1">
+                    <note pitch="C5"/>
+</script><script type="application/xml" class="markupxml diff">                    <slur side="up" target="event4" />
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+                <event value="/4" id="event2">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/4" id="event3">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4" id="event4">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/4" id="event5">
+                    <note pitch="G4"/>
+</script><script type="application/xml" class="markupxml diff">                    <slur side="down" target="event8" />
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+                <event value="/4" id="event6">
+                    <note pitch="A4"/>
+                </event>
+                <event value="/4" id="event7">
+                    <note pitch="G4"/>
+                </event>
+                <event value="/4" id="event8">
+                    <note pitch="E4"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -2299,44 +2251,40 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4" id="event1">
-</script><script type="application/xml" class="markupxml diff">                            <slur side="up" target="event4" />
-</script><script type="application/xml" class="markupxml nodiff">                            <note pitch="C5"/>
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4" id="event2">
-                            <note pitch="D5"/>
-                            <note pitch="F5"/>
-                        </event>
-                        <event value="/4" id="event3">
-                            <note pitch="E5"/>
-                            <note pitch="G5"/>
-                        </event>
-                        <event value="/4" id="event4">
-                            <note pitch="F5"/>
-                            <note pitch="A5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/4" id="event1">
+</script><script type="application/xml" class="markupxml diff">                    <slur side="up" target="event4" />
+</script><script type="application/xml" class="markupxml nodiff">                    <note pitch="C5"/>
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4" id="event2">
+                    <note pitch="D5"/>
+                    <note pitch="F5"/>
+                </event>
+                <event value="/4" id="event3">
+                    <note pitch="E5"/>
+                    <note pitch="G5"/>
+                </event>
+                <event value="/4" id="event4">
+                    <note pitch="F5"/>
+                    <note pitch="A5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -2461,43 +2409,39 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/2" id="event1">
-                            <note pitch="C5" id="note1"/>
-                            <note pitch="E5" id="note2"/>
-                            <note pitch="G5" id="note3"/>
-</script><script type="application/xml" class="markupxml diff">                            <slur side="down" target="event2"
-                                start-note="note1" end-note="note4"/>
-                            <slur side="up" target="event2"
-                                start-note="note2" end-note="note5"/>
-                            <slur side="up" target="event2"
-                                start-note="note3" end-note="note6"/>
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                        <event value="/2" id="event2">
-                            <note pitch="B4" id="note4"/>
-                            <note pitch="D5" id="note5"/>
-                            <note pitch="F5" id="note6"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/2" id="event1">
+                    <note pitch="C5" id="note1"/>
+                    <note pitch="E5" id="note2"/>
+                    <note pitch="G5" id="note3"/>
+</script><script type="application/xml" class="markupxml diff">                    <slur side="down" target="event2"
+                        start-note="note1" end-note="note4"/>
+                    <slur side="up" target="event2"
+                        start-note="note2" end-note="note5"/>
+                    <slur side="up" target="event2"
+                        start-note="note3" end-note="note6"/>
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+                <event value="/2" id="event2">
+                    <note pitch="B4" id="note4"/>
+                    <note pitch="D5" id="note5"/>
+                    <note pitch="F5" id="note6"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -2575,34 +2519,30 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/2">
-                            <note pitch="D5"/>
-</script><script type="application/xml" class="markupxml diff">                            <slur side="up" location="outgoing"/>
-</script><script type="application/xml" class="markupxml nodiff">                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/2">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/2">
+                    <note pitch="D5"/>
+</script><script type="application/xml" class="markupxml diff">                    <slur side="up" location="outgoing"/>
+</script><script type="application/xml" class="markupxml nodiff">                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -2811,94 +2751,90 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Melody</part-name>
-                <measure>
-                    <directions>
-                        <clef line="2" sign="G"/>
-                    </directions>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="G5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-            <part>
-                <part-name>Harmony</part-name>
-                <measure>
-                    <directions>
-                        <clef line="2" sign="G"/>
-                    </directions>
-                    <sequence>
-                        <event value="/2">
-                            <rest/>
-                        </event>
-                        <event value="/8">
-                            <note pitch="C5"/>
-                        </event>
-                        <event value="/8">
-                            <note pitch="D5"/>
-                        </event>
-                        <event value="/8">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/8">
-                            <note pitch="D5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2">
-                            <rest/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="G5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Melody</part-name>
+        <measure>
+            <directions>
+                <clef line="2" sign="G"/>
+            </directions>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="G5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
+    <part>
+        <part-name>Harmony</part-name>
+        <measure>
+            <directions>
+                <clef line="2" sign="G"/>
+            </directions>
+            <sequence>
+                <event value="/2">
+                    <rest/>
+                </event>
+                <event value="/8">
+                    <note pitch="C5"/>
+                </event>
+                <event value="/8">
+                    <note pitch="D5"/>
+                </event>
+                <event value="/8">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/8">
+                    <note pitch="D5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2">
+                    <rest/>
+                </event>
+                <event value="/4">
+                    <note pitch="G5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -2968,32 +2904,28 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-</script><script type="application/xml" class="markupxml diff">                        <repeat type="start"/>
-                        <repeat type="end"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+</script><script type="application/xml" class="markupxml diff">                <repeat type="start"/>
+                <repeat type="end"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -3058,31 +2990,27 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-</script><script type="application/xml" class="markupxml diff">                        <repeat type="end"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+</script><script type="application/xml" class="markupxml diff">                <repeat type="end"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -3147,33 +3075,28 @@
         <div class="markupexample">
             <h3>MNX</h3>
             <div class="markupcode">
-            <script type="application/xml" class="markupxml nodiff">
-<mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-</script><script type="application/xml" class="markupxml diff">                        <repeat type="end" times="4"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+            <script type="application/xml" class="markupxml nodiff"><mnx>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+</script><script type="application/xml" class="markupxml diff">                <repeat type="end" times="4"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -3291,72 +3214,68 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-</script><script type="application/xml" class="markupxml diff">                        <repeat type="start"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <repeat type="end"/>
-                        <ending type="start" number="1"/>
-                        <ending type="stop"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <repeat type="end"/>
-                        <ending type="start" number="2"/>
-                        <ending type="stop"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <ending type="start" number="3"/>
-                        <ending type="discontinue"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="G4"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+</script><script type="application/xml" class="markupxml diff">                <repeat type="start"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <repeat type="end"/>
+                <ending type="start" number="1"/>
+                <ending type="stop"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <repeat type="end"/>
+                <ending type="start" number="2"/>
+                <ending type="stop"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <ending type="start" number="3"/>
+                <ending type="discontinue"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="G4"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -3505,94 +3424,90 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="3/4"/>
-                        <repeat type="start"/>
-                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <ending type="start" number="1,2"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-                        <repeat type="end"/>
-</script><script type="application/xml" class="markupxml diff">                        <ending type="stop"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <ending type="start" number="3"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <ending type="discontinue"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure/>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/2d">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2d">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="E5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="D5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2d">
-                            <note pitch="G5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2">
-                            <note pitch="G5"/>
-                        </event>
-                        <event value="/4">
-                            <note pitch="F5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/2d">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="3/4"/>
+                <repeat type="start"/>
+            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <ending type="start" number="1,2"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+                <repeat type="end"/>
+</script><script type="application/xml" class="markupxml diff">                <ending type="stop"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <ending type="start" number="3"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <ending type="discontinue"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure/>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/2d">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2d">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2">
+                    <note pitch="E5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="D5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2d">
+                    <note pitch="G5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2">
+                    <note pitch="G5"/>
+                </event>
+                <event value="/4">
+                    <note pitch="F5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/2d">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -3707,70 +3622,66 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <segno/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure/>
-                <measure/>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <jump type="segno"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="F5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <segno/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure/>
+        <measure/>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <jump type="segno"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="F5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>
@@ -3892,74 +3803,70 @@
             <h3>MNX</h3>
             <div class="markupcode">
             <script type="application/xml" class="markupxml nodiff"><mnx>
-    <score>
-        <mnx-common>
-            <global>
-                <measure>
-                    <directions>
-                        <time signature="4/4"/>
-                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <segno/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <fine/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-                <measure/>
-                <measure>
-                    <directions>
-</script><script type="application/xml" class="markupxml diff">                        <jump type="dsalfine"/>
-</script><script type="application/xml" class="markupxml nodiff">                    </directions>
-                </measure>
-            </global>
-            <part>
-                <part-name>Music</part-name>
-                <measure>
-                    <directions>
-                        <clef sign="G" line="2"/>
-                    </directions>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="E5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="F5"/>
-                        </event>
-                    </sequence>
-                </measure>
-                <measure>
-                    <sequence>
-                        <event value="/1">
-                            <note pitch="C5"/>
-                        </event>
-                    </sequence>
-                </measure>
-            </part>
-        </mnx-common>
-    </score>
+    <global>
+        <measure>
+            <directions>
+                <time signature="4/4"/>
+            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <segno/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <fine/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+        <measure/>
+        <measure>
+            <directions>
+</script><script type="application/xml" class="markupxml diff">                <jump type="dsalfine"/>
+</script><script type="application/xml" class="markupxml nodiff">            </directions>
+        </measure>
+    </global>
+    <part>
+        <part-name>Music</part-name>
+        <measure>
+            <directions>
+                <clef sign="G" line="2"/>
+            </directions>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="E5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="F5"/>
+                </event>
+            </sequence>
+        </measure>
+        <measure>
+            <sequence>
+                <event value="/1">
+                    <note pitch="C5"/>
+                </event>
+            </sequence>
+        </measure>
+    </part>
 </mnx></script>
             </div>
         </div>

--- a/specification/common/index.bs
+++ b/specification/common/index.bs
@@ -114,7 +114,7 @@ url: http://music-encoding.org/#; type: dfn;
 
 url: https://www.w3.org/TR/SVG/linking.html#LinksIntoSVG; type: dfn;
     text: Linking into SVG content
-
+    
 </pre>
 <pre class="link-defaults">
 spec:dom; type:dfn; text:attribute
@@ -1023,34 +1023,6 @@ a <a>SMuFL glyph name</a> from the catalog of glyph names defined in the
 
 <h3 id="root-structure">Root structure and metadata</h3>
 
-<h4 id="the-mnx-element">The <dfn element><code>mnx</code></dfn> element</h4>
-<section dfn-for="mnx">
-  <dl class="def">
-    <dt><a>Contexts</a>:</dt>
-    <dd>None: this is the top-level element.</dd>
-    <dt><a>Content Model</a>:</dt>
-    <dd>A single, optional <{head}> element.</dd>
-    <dd>Either a <{collection}> or a <{score}> element.</dd>
-    <dt><a>Attributes</a>:</dt>
-    <dd>None.</dd>
-  </dl>
-
-The <{mnx}> element encloses the document as a whole.
-
-<div class="example">
-```xml
-<mnx xmlns="http://www.w3.org/mnx">
-    <head>
-      ...head content...
-    </head>
-    <score>
-      ...musical body content...
-    </score>
-</mnx>
-```
-</div>
-</section>
-
 <h4 id="the-head-element">The <dfn element><code>head</code></dfn> element</h4>
 <section dfn-for="head">
   <dl class="def">
@@ -1066,85 +1038,30 @@ The <{head}> element supplies overall descriptive information for an MNX documen
 such as document-scoped metadata or <a>stylesheet definitions</a>.
 </section>
 
-<h4 id="the-collection-element">The <dfn element><code>collection</code></dfn> element</h4>
-<section dfn-for="collection">
-  <dl class="def">
-    <dt><a>Contexts</a>:</dt>
-    <dd><{mnx}>, <{collection}></dd>
-    <dt><a>Content Model</a>:</dt>
-    <dd>Any combination of <{collection}> and <{score}> elements.</dd>
-    <dt><a>Attributes</a>:</dt>
-    <dd><{collection/type}> - The type of the collection</dd>
-  </dl>
-
-The <{collection}> element describes a collection, which is a sequence of
-ordered elements that make up a compound musical document. Each child element
-of the collection may itself be either a collection or a score.
-
-The <dfn element-attr>type</dfn> attribute determines the nature of the collection.
-Valid collection type values include:
-
-<dl dfn-for="collection/type">
-  <dt><dfn attr-value><code>movements</code></dfn></dt>
-  <dd>Each element comprises a movement of a work.</dd>
-  <dt><dfn attr-value><code>sections</code></dfn></dt>
-  <dd>Each element comprises a section of a work, or of a movement.</dd>
-  <dt><dfn attr-value><code>parts</code></dfn></dt>
-  <dd>Each element comprises a description of of the same music, organized for different parts.</dd>
-</dl>
-
-<a>Metadata content</a> or <a>style properties</a> may be included at any level
-of the resulting structure, causing them to apply them only to those parts of
-the document.
-
-The following example shows a hierarchy of collections and scores.
-
-<div class="example">
-```xml
-    <collection type="sections">
-        <score>
-            <title>Section 1 (for Flute and Cello)</title>
-            <mnx-common>...</mnx-common>
-        </score>
-        <collection type="movements">
-            <title>Section 2</title>
-            <score>
-                <title>Section 2, Movement 1 (for Solo Flute)</title>
-                <mnx-common>...</mnx-common>
-            </score>
-            <score>
-                <title>Section 2, Movement 2 (for Solo Cello)</title>
-                <mnx-common>...</mnx-common>
-            </score>
-        </collection>
-        <score>
-            <title>Section 3 (for Flute and Cello)</title>
-            <mnx-common>...</mnx-common>
-        </score>
-    </collection>
-```
-</div>
-
-</section>
-
-<h4 id="the-score-element">The <dfn element><code>score</code></dfn> element</h4>
+<h4 id="the-score-element">The <dfn element=""><code>score</code></dfn> element</h4>
 <section dfn-for="score">
   <dl class="def">
     <dt><a>Contexts</a>:</dt>
-    <dd><{mnx}>, <{collection}>.</dd>
+    <dd>TBD: This element's context is currently under discussion.</dd>
     <dt><a>Content Model</a>:</dt>
     <dd><a>Metadata content</a></dd>
-    <dd>Zero or one <{mnx-common}> elements.</dd>
+    <dd><{stylesheet}></dd>
+    <dd>TBD: This element's further content is currently under discussion.</dd>
     <dt><a>Attributes</a>:</dt>
     <dd><{score/src}> - optional relative path to an external source file</dd>
   </dl>
-
 The <{score}> element encloses a self-contained description of the score for
 a portion or the entirety of a musical work.
 
-If the <dfn element-attr>src</dfn> attribute is provided, this specifies a
+If the <dfn element-attr="">src</dfn> attribute is provided, this specifies a
 relative path where the score's musical body lives. Otherwise, the body
 must be provided within the content of the <{score}> element.
+<p class="note">
+Note: Both the context and content of this element are currently under discussion.<br />
+See the proposals for a <em><b>staff-group</b></em> element mentioned in
+<a href="https://www.w3.org/community/music-notation/2020/07/07/co-chair-meeting-minutes-july-7-2020/">
+    The Co-Chair Meeting Minutes: July 7, 2020</a>
+</p>
 </section>
 
 <h4 id="mnx-metadata-content">Metadata content</h4>
@@ -1168,13 +1085,13 @@ bibliographic data and other descriptive information.
 The <{title}> element assigns a title to its parent element in the context of the document as a whole.
 </section>
 
-<h4 id="the-mnx-common-element">The <dfn element><code>mnx-common</code></dfn> element</h4>
+<h4 id="the-mnx-common-element">The <dfn element><code>mnx</code></dfn> element</h4>
 
-<section dfn-for="mnx-common">
+<section dfn-for="mnx">
 
   <dl class="def">
     <dt><a>Contexts</a>:</dt>
-    <dd><{score}>.</dd>
+    <dd>None: this is the top-level element.</dd>
     <dt><a>Content Model</a>:</dt>
     <dd><a>Metadata content</a>.</dd>
     <dd><{stylesheet}>.</dd>
@@ -1185,13 +1102,13 @@ The <{title}> element assigns a title to its parent element in the context of th
     <dd>None.</dd>
   </dl>
 
-The <{mnx-common}> element describes an MNX score as a whole.
+The <{mnx}> element describes an MNX score as a whole.
 
-The following example provides the basic skeleton of a <{mnx-common}> musical body:
+The following example provides the basic skeleton of a <{mnx}> musical body:
 
 <div class="example">
 ```xml
-<mnx-common>
+<mnx>
   <global>
       ...measure content describing system-wide features...
   </global>
@@ -1204,7 +1121,7 @@ The following example provides the basic skeleton of a <{mnx-common}> musical bo
       ...measure content for part 2...
   </part>
   ...additional parts...
-</mnx-common>
+</mnx>
 ```
 </div>
 </section>
@@ -1214,7 +1131,7 @@ The following example provides the basic skeleton of a <{mnx-common}> musical bo
 <section dfn-for="global">
   <dl class="def">
     <dt><a>Contexts</a>:</dt>
-    <dd><{mnx-common}></dd>
+    <dd><{mnx}></dd>
     <dt><a>Content Model</a>:</dt>
     <dd><a>Measure content</a>, which must not include any <a>sequence content</a></dd>
     <dt><a>Attributes</a>:</dt>
@@ -1256,7 +1173,7 @@ tempo indications.
 <section dfn-for="part">
   <dl class="def">
     <dt><a>Contexts</a>:</dt>
-    <dd><{mnx-common}></dd>
+    <dd><{mnx}></dd>
     <dt><a>Content Model</a>:</dt>
     <dd><a>Part description content</a></dd>
     <dd><a>Measure content</a></dd>
@@ -3053,7 +2970,7 @@ audio media representing recordings of the score.
 
   <dl class="def">
     <dt><a>Contexts</a>:</dt>
-    <dd><{mnx-common}></dd>
+    <dd><{mnx}></dd>
     <dt><a>Content Model</a>:</dt>
     <dd>One or more <{score-audio-media}> elements.</dd>
     <dd>Zero or one <{score-audio-mapping}> elements.</dd>
@@ -3176,7 +3093,7 @@ remainder of the recording.
 
 <div class="example">
 ```xml
-<mnx-common>
+<mnx>
   <global id="global1">...</global>
   <part>...</part>
   <part>...</part>
@@ -3189,7 +3106,7 @@ remainder of the recording.
      <score-audio-mapping start="7.53" end="10.53" start="3:0" end="5:1"/>   ...2nd repeat...
      <score-audio-mapping start="10.53" end="11.53" start="7:0" end="7:1"/>  ...2nd and final ending.
   </score-audio>
-</mnx-common>
+</mnx>
 ```
 </div>
 
@@ -3555,14 +3472,14 @@ in a <a>style selector definition</a>. Taken together, these supply a set of
 <dfn>stylesheet definitions</dfn> that control the rendering and
 interpretation of the document.
 
-These definitions may be placed in the <{head}>, the <{mnx-common}>
+These definitions may be placed in the <{head}>, the <{mnx}>
 element, or in a separate linked stylesheet.
 
 <h4 id="the-stylesheet-element">The <dfn element><code>stylesheet</code></dfn> element</h4>
 <section dfn-for="stylesheet">
   <dl class="def">
     <dt><a>Contexts</a>:</dt>
-    <dd><{head}>, <{mnx-common}></dd>
+    <dd><{head}>, <{mnx}></dd>
     <dt><a>Content Model</a>:</dt>
     <dd><a>Stylesheet definitions</a>.</dd>
   </dl>

--- a/specification/common/index.bs
+++ b/specification/common/index.bs
@@ -1038,32 +1038,6 @@ The <{head}> element supplies overall descriptive information for an MNX documen
 such as document-scoped metadata or <a>stylesheet definitions</a>.
 </section>
 
-<h4 id="the-score-element">The <dfn element=""><code>score</code></dfn> element</h4>
-<section dfn-for="score">
-  <dl class="def">
-    <dt><a>Contexts</a>:</dt>
-    <dd>TBD: This element's context is currently under discussion.</dd>
-    <dt><a>Content Model</a>:</dt>
-    <dd><a>Metadata content</a></dd>
-    <dd><{stylesheet}></dd>
-    <dd>TBD: This element's further content is currently under discussion.</dd>
-    <dt><a>Attributes</a>:</dt>
-    <dd><{score/src}> - optional relative path to an external source file</dd>
-  </dl>
-The <{score}> element encloses a self-contained description of the score for
-a portion or the entirety of a musical work.
-
-If the <dfn element-attr="">src</dfn> attribute is provided, this specifies a
-relative path where the score's musical body lives. Otherwise, the body
-must be provided within the content of the <{score}> element.
-<p class="note">
-Note: Both the context and content of this element are currently under discussion.<br />
-See the proposals for a <em><b>staff-group</b></em> element mentioned in
-<a href="https://www.w3.org/community/music-notation/2020/07/07/co-chair-meeting-minutes-july-7-2020/">
-    The Co-Chair Meeting Minutes: July 7, 2020</a>
-</p>
-</section>
-
 <h4 id="mnx-metadata-content">Metadata content</h4>
 
 <dfn>Metadata content</dfn> may be included in many elements to supply

--- a/specification/common/index.bs
+++ b/specification/common/index.bs
@@ -114,7 +114,7 @@ url: http://music-encoding.org/#; type: dfn;
 
 url: https://www.w3.org/TR/SVG/linking.html#LinksIntoSVG; type: dfn;
     text: Linking into SVG content
-    
+
 </pre>
 <pre class="link-defaults">
 spec:dom; type:dfn; text:attribute


### PR DESCRIPTION
This Pull Request is the first of a pair of PRs, that together complete the renaming of MNX-Common to MNX.
**Part 1** (this PR) consists of a revision of the [MNX Draft Specification](https://w3c.github.io/mnx/specification/common/#the-score-element) in which:  
   1. The current `<mnx>` definition (the MNX-Container) has been removed.
   2. The `<collection>` element has been removed (it was required only by the MNX-Container).
   3. The `<mnx-common>` element has been renamed `<mnx>`.
   4. The definition of `<score>` has been corrected and a note has been added.
This element's context and content are currently under discussion. See the [Co-Chair Meeting Minutes: July 7, 2020](https://www.w3.org/community/music-notation/2020/07/07/co-chair-meeting-minutes-july-7-2020). 
[Edit 07.10.20: The `<score>` element has now been _deleted_. It is not part of the current `mnx-common` element, so does not belong in this revision.]
   5. Other texts have been updated only to ensure that the document is consistent.
The intention is to preserve the content of the current document as exactly as possible while renaming `<mnx-common>` as `<mnx>`.

**Part 2** (a separate PR) adds a new **MNX-Container Draft Specification** to this repository.
In the new document, the `<mnx>` element that was removed by this PR, is replaced by an `<mnx-container>` element.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/notator/mnx/pull/201.html" title="Last updated on Oct 24, 2020, 12:32 PM UTC (88b4ad0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mnx/201/da4d333...notator:88b4ad0.html" title="Last updated on Oct 24, 2020, 12:32 PM UTC (88b4ad0)">Diff</a>