### PR TITLE
Change part-measure objects to use separate arrays for clefs and sequences

### DIFF
--- a/docgenerator/data.json
+++ b/docgenerator/data.json
@@ -3479,24 +3479,13 @@
 },
 {
     "model": "spec.jsonobject",
-    "pk": 138,
-    "fields": {
-        "name": "rhythmic position",
-        "slug": "rhythmic-position",
-        "schema": 1,
-        "object_type": 2,
-        "description": ""
-    }
-},
-{
-    "model": "spec.jsonobject",
     "pk": 139,
     "fields": {
         "name": "positioned clef",
         "slug": "positioned-clef",
         "schema": 1,
         "object_type": 1,
-        "description": "<p>Represents a clef as positioned at a specific location within a measure.</p>"
+        "description": "<p>Represents a clef as positioned at a specific location within a measure.</p>\r\n\r\n<p>If the position isn't encoded, the position is assumed to be the start of the measure.</p>\r\n\r\n<p>Note: This object will eventually include a \"position\" key, but we haven't yet designed how that will be encoded.</p>"
     }
 },
 {
@@ -5653,17 +5642,6 @@
         "child": 19,
         "is_required": true,
         "description": ""
-    }
-},
-{
-    "model": "spec.jsonobjectrelationship",
-    "pk": 217,
-    "fields": {
-        "parent": 139,
-        "child_key": "position",
-        "child": 138,
-        "is_required": false,
-        "description": "The clef's position in the measure. If absent, this value is assumed to be [0, 1], the start of the measure."
     }
 },
 {

--- a/docgenerator/data.json
+++ b/docgenerator/data.json
@@ -2258,17 +2258,6 @@
 },
 {
     "model": "spec.jsonobject",
-    "pk": 18,
-    "fields": {
-        "name": "measure contents",
-        "slug": "measure-contents",
-        "schema": 1,
-        "object_type": 2,
-        "description": ""
-    }
-},
-{
-    "model": "spec.jsonobject",
     "pk": 19,
     "fields": {
         "name": "clef",
@@ -2291,17 +2280,6 @@
 },
 {
     "model": "spec.jsonobject",
-    "pk": 21,
-    "fields": {
-        "name": "literal-string-clef",
-        "slug": "literal-string-clef",
-        "schema": 1,
-        "object_type": 6,
-        "description": "clef"
-    }
-},
-{
-    "model": "spec.jsonobject",
     "pk": 22,
     "fields": {
         "name": "clef sign",
@@ -2320,17 +2298,6 @@
         "schema": 1,
         "object_type": 4,
         "description": ""
-    }
-},
-{
-    "model": "spec.jsonobject",
-    "pk": 24,
-    "fields": {
-        "name": "literal-string-sequence",
-        "slug": "literal-string-sequence",
-        "schema": 1,
-        "object_type": 6,
-        "description": "sequence"
     }
 },
 {
@@ -3489,6 +3456,50 @@
     }
 },
 {
+    "model": "spec.jsonobject",
+    "pk": 136,
+    "fields": {
+        "name": "positioned clef list",
+        "slug": "positioned-clef-list",
+        "schema": 1,
+        "object_type": 2,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobject",
+    "pk": 137,
+    "fields": {
+        "name": "sequence list",
+        "slug": "sequence-list",
+        "schema": 1,
+        "object_type": 2,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobject",
+    "pk": 138,
+    "fields": {
+        "name": "rhythmic position",
+        "slug": "rhythmic-position",
+        "schema": 1,
+        "object_type": 2,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobject",
+    "pk": 139,
+    "fields": {
+        "name": "positioned clef",
+        "slug": "positioned-clef",
+        "schema": 1,
+        "object_type": 1,
+        "description": "<p>Represents a clef as positioned at a specific location within a measure.</p>"
+    }
+},
+{
     "model": "spec.jsonobjectrelationship",
     "pk": 1,
     "fields": {
@@ -3655,50 +3666,6 @@
 },
 {
     "model": "spec.jsonobjectrelationship",
-    "pk": 17,
-    "fields": {
-        "parent": 16,
-        "child_key": "content",
-        "child": 18,
-        "is_required": true,
-        "description": ""
-    }
-},
-{
-    "model": "spec.jsonobjectrelationship",
-    "pk": 18,
-    "fields": {
-        "parent": 18,
-        "child_key": "0",
-        "child": 19,
-        "is_required": false,
-        "description": ""
-    }
-},
-{
-    "model": "spec.jsonobjectrelationship",
-    "pk": 19,
-    "fields": {
-        "parent": 18,
-        "child_key": "1",
-        "child": 20,
-        "is_required": false,
-        "description": ""
-    }
-},
-{
-    "model": "spec.jsonobjectrelationship",
-    "pk": 20,
-    "fields": {
-        "parent": 19,
-        "child_key": "type",
-        "child": 21,
-        "is_required": true,
-        "description": ""
-    }
-},
-{
-    "model": "spec.jsonobjectrelationship",
     "pk": 21,
     "fields": {
         "parent": 19,
@@ -3717,17 +3684,6 @@
         "child": 23,
         "is_required": true,
         "description": "The staff line associated with the clef sign."
-    }
-},
-{
-    "model": "spec.jsonobjectrelationship",
-    "pk": 23,
-    "fields": {
-        "parent": 20,
-        "child_key": "type",
-        "child": 24,
-        "is_required": true,
-        "description": ""
     }
 },
 {
@@ -5645,6 +5601,72 @@
     }
 },
 {
+    "model": "spec.jsonobjectrelationship",
+    "pk": 211,
+    "fields": {
+        "parent": 136,
+        "child_key": "0",
+        "child": 139,
+        "is_required": false,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 212,
+    "fields": {
+        "parent": 137,
+        "child_key": "0",
+        "child": 20,
+        "is_required": false,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 213,
+    "fields": {
+        "parent": 16,
+        "child_key": "clefs",
+        "child": 136,
+        "is_required": false,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 215,
+    "fields": {
+        "parent": 16,
+        "child_key": "sequences",
+        "child": 137,
+        "is_required": true,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 216,
+    "fields": {
+        "parent": 139,
+        "child_key": "clef",
+        "child": 19,
+        "is_required": true,
+        "description": ""
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 217,
+    "fields": {
+        "parent": 139,
+        "child_key": "position",
+        "child": 138,
+        "is_required": false,
+        "description": "The clef's position in the measure. If absent, this value is assumed to be [0, 1], the start of the measure."
+    }
+},
+{
     "model": "spec.exampledocument",
     "pk": 1,
     "fields": {
@@ -5652,7 +5674,7 @@
         "slug": "hello-world",
         "schema": 1,
         "blurb": "This basic MNX document contains a single middle C whole note, on a treble clef stave, in 4/4 time.",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/hello-world.png",
         "is_featured": true
     }
@@ -5665,7 +5687,7 @@
         "slug": "two-bar-c-major-scale",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {\r\n        \"barline\": {\"type\": \"regular\"}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {\r\n        \"barline\": {\"type\": \"regular\"}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/two-bar-c-major-scale.png",
         "is_featured": false
     }
@@ -5678,7 +5700,7 @@
         "slug": "three-note-chord-and-half-rest",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/three-note-chord-and-half-rest.png",
         "is_featured": false
     }
@@ -5691,7 +5713,7 @@
         "slug": "time-signatures",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {\r\n        \"time\": {\"count\": 2, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {\r\n        \"time\": {\"count\": 2, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/time-signatures.png",
         "is_featured": false
     }
@@ -5704,7 +5726,7 @@
         "slug": "key-signatures",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"key\": {\"fifths\": 4},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {\r\n        \"key\": {\"fifths\": -4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5, \"alter\": 1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5, \"alter\": 1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5, \"alter\": 1}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"key\": {\"fifths\": 4},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {\r\n        \"key\": {\"fifths\": -4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5, \"alter\": 1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5, \"alter\": 1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5, \"alter\": 1}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/key-signatures.png",
         "is_featured": false
     }
@@ -5717,7 +5739,7 @@
         "slug": "accidentals",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"key\": {\"fifths\": -2},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"G\", \"octave\": 4, \"alter\": 1},\r\n                      \"accidentalDisplay\": {\"show\": \"true\"}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"D\", \"octave\": 5, \"alter\": -1},\r\n                      \"accidentalDisplay\": {\"show\": \"true\"}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5, \"alter\": -1}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"D\", \"octave\": 5},\r\n                      \"accidentalDisplay\": {\"show\": \"true\"}\r\n                    }\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"key\": {\"fifths\": -2},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"G\", \"octave\": 4, \"alter\": 1},\r\n                      \"accidentalDisplay\": {\"show\": \"true\"}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"D\", \"octave\": 5, \"alter\": -1},\r\n                      \"accidentalDisplay\": {\"show\": \"true\"}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5, \"alter\": -1}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"D\", \"octave\": 5},\r\n                      \"accidentalDisplay\": {\"show\": \"true\"}\r\n                    }\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/accidentals.png",
         "is_featured": false
     }
@@ -5730,7 +5752,7 @@
         "slug": "dotted-notes",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}},\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/dotted-notes.png",
         "is_featured": false
     }
@@ -5743,7 +5765,7 @@
         "slug": "ties",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}, \"tied\": {\"target\": \"note3\"}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}, \"id\": \"note3\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"tied\": {\"target\": \"note5\"}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"id\": \"note5\", \"tied\": {\"target\": \"note6\"}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"id\": \"note6\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}, \"tied\": {\"target\": \"note3\"}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}, \"id\": \"note3\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"tied\": {\"target\": \"note5\"}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"id\": \"note5\", \"tied\": {\"target\": \"note6\"}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"id\": \"note6\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/ties.png",
         "is_featured": false
     }
@@ -5756,7 +5778,7 @@
         "slug": "beams",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\"]},\r\n            {\"events\": [\"ev5\", \"ev6\", \"ev7\", \"ev8\"]}\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev9\", \"ev10\", \"ev11\", \"ev12\", \"ev13\"],\r\n               \"inner\": [\r\n                  {\"events\": [\"ev11\", \"ev12\"]}\r\n               ]\r\n            },\r\n            {\"events\": [\"ev15\", \"ev15\"]}\r\n          ],\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev10\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev11\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev12\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev13\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev14\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev15\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\"]},\r\n            {\"events\": [\"ev5\", \"ev6\", \"ev7\", \"ev8\"]}\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev9\", \"ev10\", \"ev11\", \"ev12\", \"ev13\"],\r\n               \"inner\": [\r\n                  {\"events\": [\"ev11\", \"ev12\"]}\r\n               ]\r\n            },\r\n            {\"events\": [\"ev15\", \"ev15\"]}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev10\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev11\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev12\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev13\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev14\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev15\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/beams.png",
         "is_featured": false
     }
@@ -5769,7 +5791,7 @@
         "slug": "beams-secondary-beam-breaks",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\", \"ev5\", \"ev6\", \"ev7\", \"ev8\"],\r\n               \"inner\": [\r\n                  {\r\n                     \"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\"],\r\n                     \"inner\": [{\r\n                        \"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\"]\r\n                     }]\r\n                  },\r\n                  {\r\n                     \"events\": [\"ev5\", \"ev6\", \"ev7\", \"ev8\"],\r\n                     \"inner\": [{\r\n                        \"events\": [\"ev5\", \"ev6\", \"ev7\", \"ev8\"]\r\n                     }]\r\n                  }\r\n               ]\r\n            },\r\n            {\r\n               \"events\": [\"ev9\", \"ev10\", \"ev11\", \"ev12\", \"ev13\", \"ev14\", \"ev15\", \"ev16\"],\r\n               \"inner\": [\r\n                  {\r\n                     \"events\": [\"ev9\", \"ev10\", \"ev11\", \"ev12\"],\r\n                     \"inner\": [\r\n                        {\"events\": [\"ev9\", \"ev10\"]},\r\n                        {\"events\": [\"ev11\", \"ev12\"]}\r\n                     ]\r\n                  },\r\n                  {\r\n                     \"events\": [\"ev13\", \"ev14\", \"ev15\", \"ev16\"],\r\n                     \"inner\": [\r\n                        {\"events\": [\"ev13\", \"ev14\"]},\r\n                        {\"events\": [\"ev15\", \"ev16\"]}\r\n                     ]\r\n                  }\r\n               ]\r\n            }\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev10\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev11\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev12\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev13\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev14\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev15\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev16\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\", \"ev5\", \"ev6\", \"ev7\", \"ev8\"],\r\n               \"inner\": [\r\n                  {\r\n                     \"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\"],\r\n                     \"inner\": [{\r\n                        \"events\": [\"ev1\", \"ev2\", \"ev3\", \"ev4\"]\r\n                     }]\r\n                  },\r\n                  {\r\n                     \"events\": [\"ev5\", \"ev6\", \"ev7\", \"ev8\"],\r\n                     \"inner\": [{\r\n                        \"events\": [\"ev5\", \"ev6\", \"ev7\", \"ev8\"]\r\n                     }]\r\n                  }\r\n               ]\r\n            },\r\n            {\r\n               \"events\": [\"ev9\", \"ev10\", \"ev11\", \"ev12\", \"ev13\", \"ev14\", \"ev15\", \"ev16\"],\r\n               \"inner\": [\r\n                  {\r\n                     \"events\": [\"ev9\", \"ev10\", \"ev11\", \"ev12\"],\r\n                     \"inner\": [\r\n                        {\"events\": [\"ev9\", \"ev10\"]},\r\n                        {\"events\": [\"ev11\", \"ev12\"]}\r\n                     ]\r\n                  },\r\n                  {\r\n                     \"events\": [\"ev13\", \"ev14\", \"ev15\", \"ev16\"],\r\n                     \"inner\": [\r\n                        {\"events\": [\"ev13\", \"ev14\"]},\r\n                        {\"events\": [\"ev15\", \"ev16\"]}\r\n                     ]\r\n                  }\r\n               ]\r\n            }\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev10\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev11\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev12\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev13\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev14\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev15\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev16\",\r\n                  \"duration\": {\"base\": \"32nd\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/beams-secondary-beam-breaks.png",
         "is_featured": false
     }
@@ -5782,7 +5804,7 @@
         "slug": "beam-hooks",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev1\", \"ev2\", \"ev3\"],\r\n               \"hooks\": [\r\n                  {\"direction\": \"right\", \"event\": \"ev1\"},\r\n                  {\"direction\": \"left\", \"event\": \"ev3\"}\r\n               ]\r\n            },\r\n            {\r\n               \"events\": [\"ev4\", \"ev5\", \"ev6\"],\r\n               \"hooks\": [\r\n                  {\"direction\": \"right\", \"event\": \"ev4\"},\r\n                  {\"direction\": \"left\", \"event\": \"ev6\"}\r\n               ]\r\n            },\r\n            {\r\n               \"events\": [\"ev7\", \"ev8\", \"ev9\"],\r\n               \"hooks\": [\r\n                  {\"direction\": \"right\", \"event\": \"ev7\"},\r\n                  {\"direction\": \"left\", \"event\": \"ev9\"}\r\n               ]\r\n            }\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev1\", \"ev2\", \"ev3\"],\r\n               \"hooks\": [\r\n                  {\"direction\": \"right\", \"event\": \"ev1\"},\r\n                  {\"direction\": \"left\", \"event\": \"ev3\"}\r\n               ]\r\n            },\r\n            {\r\n               \"events\": [\"ev4\", \"ev5\", \"ev6\"],\r\n               \"hooks\": [\r\n                  {\"direction\": \"right\", \"event\": \"ev4\"},\r\n                  {\"direction\": \"left\", \"event\": \"ev6\"}\r\n               ]\r\n            },\r\n            {\r\n               \"events\": [\"ev7\", \"ev8\", \"ev9\"],\r\n               \"hooks\": [\r\n                  {\"direction\": \"right\", \"event\": \"ev7\"},\r\n                  {\"direction\": \"left\", \"event\": \"ev9\"}\r\n               ]\r\n            }\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"16th\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/beam-hooks.png",
         "is_featured": false
     }
@@ -5795,7 +5817,7 @@
         "slug": "beams-inner-grace-notes",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n   \"global\": {\r\n      \"measures\": [\r\n         {\r\n            \"time\": {\r\n               \"count\": 4,\r\n               \"unit\": 4\r\n            }\r\n         }\r\n      ]\r\n   },\r\n   \"mnx\": {\r\n      \"version\": 1\r\n   },\r\n   \"parts\": [\r\n      {\r\n         \"measures\": [\r\n            {\r\n               \"beams\": [\r\n                  {\r\n                     \"events\": [\r\n                        \"ev1\",\r\n                        \"ev3\",\r\n                        \"ev4\",\r\n                        \"ev5\"\r\n                     ]\r\n                  }\r\n               ],\r\n               \"content\": [\r\n                  {\r\n                     \"type\": \"clef\",\r\n                     \"line\": 2,\r\n                     \"sign\": \"G\"\r\n                  },\r\n                  {\r\n                     \"type\": \"sequence\",\r\n                     \"content\": [\r\n                        {\r\n                           \"id\": \"ev1\",\r\n                           \"type\": \"event\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"C\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"grace\",\r\n                           \"content\": [\r\n                              {\r\n                                 \"type\": \"event\",\r\n                                 \"duration\": {\r\n                                    \"base\": \"eighth\"\r\n                                 },\r\n                                 \"notes\": [\r\n                                    {\r\n                                       \"pitch\": {\r\n                                          \"octave\": 4,\r\n                                          \"step\": \"B\"\r\n                                       }\r\n                                    }\r\n                                 ]\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"id\": \"ev3\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"D\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"id\": \"ev4\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"E\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"id\": \"ev5\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"F\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"duration\": {\r\n                              \"base\": \"half\"\r\n                           },\r\n                           \"rest\": {}\r\n                        }\r\n                     ]\r\n                  }\r\n               ]\r\n            }\r\n         ]\r\n      }\r\n   ]\r\n}",
+        "document": "{\r\n   \"global\": {\r\n      \"measures\": [\r\n         {\r\n            \"time\": {\r\n               \"count\": 4,\r\n               \"unit\": 4\r\n            }\r\n         }\r\n      ]\r\n   },\r\n   \"mnx\": {\r\n      \"version\": 1\r\n   },\r\n   \"parts\": [\r\n      {\r\n         \"measures\": [\r\n            {\r\n               \"beams\": [\r\n                  {\r\n                     \"events\": [\r\n                        \"ev1\",\r\n                        \"ev3\",\r\n                        \"ev4\",\r\n                        \"ev5\"\r\n                     ]\r\n                  }\r\n               ],\r\n               \"clefs\": [\r\n                  {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n               ],\r\n               \"sequences\": [\r\n                  {\r\n                     \"content\": [\r\n                        {\r\n                           \"id\": \"ev1\",\r\n                           \"type\": \"event\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"C\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"grace\",\r\n                           \"content\": [\r\n                              {\r\n                                 \"type\": \"event\",\r\n                                 \"duration\": {\r\n                                    \"base\": \"eighth\"\r\n                                 },\r\n                                 \"notes\": [\r\n                                    {\r\n                                       \"pitch\": {\r\n                                          \"octave\": 4,\r\n                                          \"step\": \"B\"\r\n                                       }\r\n                                    }\r\n                                 ]\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"id\": \"ev3\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"D\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"id\": \"ev4\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"E\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"id\": \"ev5\",\r\n                           \"duration\": {\r\n                              \"base\": \"eighth\"\r\n                           },\r\n                           \"notes\": [\r\n                              {\r\n                                 \"pitch\": {\r\n                                    \"octave\": 5,\r\n                                    \"step\": \"F\"\r\n                                 }\r\n                              }\r\n                           ]\r\n                        },\r\n                        {\r\n                           \"type\": \"event\",\r\n                           \"duration\": {\r\n                              \"base\": \"half\"\r\n                           },\r\n                           \"rest\": {}\r\n                        }\r\n                     ]\r\n                  }\r\n               ]\r\n            }\r\n         ]\r\n      }\r\n   ]\r\n}",
         "image_url": "/static/examples/beams-inner-grace-notes.png",
         "is_featured": false
     }
@@ -5808,7 +5830,7 @@
         "slug": "beams-across-barlines",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev3\", \"ev4\", \"ev5\", \"ev6\"]\r\n            }\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                     {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                     {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev3\", \"ev4\", \"ev5\", \"ev6\"]\r\n            }\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                     {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                     {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/beams-across-barlines.png",
         "is_featured": false
     }
@@ -5821,7 +5843,7 @@
         "slug": "tuplets",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev3\", \"ev4\", \"ev5\"]\r\n            }\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"tuplet\",\r\n                  \"inner\": {\"multiple\": 3, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"outer\": {\"multiple\": 2, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"content\": [\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                        ]\r\n                     }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"tuplet\",\r\n                  \"inner\": {\"multiple\": 3, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"outer\": {\"multiple\": 2, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"content\": [\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"id\": \"ev3\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"id\": \"ev4\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"id\": \"ev5\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                        ]\r\n                     }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"tuplet\",\r\n                  \"inner\": {\"multiple\": 6, \"duration\": {\"base\": \"quarter\"}},\r\n                  \"outer\": {\"multiple\": 4, \"duration\": {\"base\": \"quarter\"}},\r\n                  \"content\": [\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     }\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n               \"events\": [\"ev3\", \"ev4\", \"ev5\"]\r\n            }\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"tuplet\",\r\n                  \"inner\": {\"multiple\": 3, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"outer\": {\"multiple\": 2, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"content\": [\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                        ]\r\n                     }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"tuplet\",\r\n                  \"inner\": {\"multiple\": 3, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"outer\": {\"multiple\": 2, \"duration\": {\"base\": \"eighth\"}},\r\n                  \"content\": [\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"id\": \"ev3\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"id\": \"ev4\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"F\", \"octave\": 4}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"id\": \"ev5\",\r\n                        \"duration\": {\"base\": \"eighth\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                        ]\r\n                     }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"tuplet\",\r\n                  \"inner\": {\"multiple\": 6, \"duration\": {\"base\": \"quarter\"}},\r\n                  \"outer\": {\"multiple\": 4, \"duration\": {\"base\": \"quarter\"}},\r\n                  \"content\": [\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                        ]\r\n                     },\r\n                     {\r\n                        \"type\": \"event\",\r\n                        \"duration\": {\"base\": \"quarter\"},\r\n                        \"notes\": [\r\n                           {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                        ]\r\n                     }\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/tuplets.png",
         "is_featured": false
     }
@@ -5834,7 +5856,7 @@
         "slug": "multiple-voices",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/multiple-voices.png",
         "is_featured": true
     }
@@ -5847,7 +5869,7 @@
         "slug": "octave-shifts-8va",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"octave-shift\",\r\n                  \"value\": -8,\r\n                  \"end\": \"2:1/2\"\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 7}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 7}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 7}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"octave-shift\",\r\n                  \"value\": -8,\r\n                  \"end\": \"2:1/2\"\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 7}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 7}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 7}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/octave-shifts-8va.png",
         "is_featured": false
     }
@@ -5860,7 +5882,7 @@
         "slug": "slurs",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"up\", \"target\": \"ev4\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"down\", \"target\": \"ev8\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"up\", \"target\": \"ev4\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev5\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"down\", \"target\": \"ev8\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/slurs.png",
         "is_featured": false
     }
@@ -5873,7 +5895,7 @@
         "slug": "slurs-chords",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"up\", \"target\": \"ev4\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"up\", \"target\": \"ev4\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev3\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev4\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}},\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/slurs-chords.png",
         "is_featured": false
     }
@@ -5886,7 +5908,7 @@
         "slug": "slurs-targeting-specific-notes",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"id\": \"note1\"},\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}, \"id\": \"note2\"},\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}, \"id\": \"note3\"}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"down\", \"target\": \"ev2\", \"start-note\": \"note1\", \"end-note\": \"note4\"},\r\n                    {\"side\": \"up\", \"target\": \"ev2\", \"start-note\": \"note2\", \"end-note\": \"note5\"},\r\n                    {\"side\": \"up\", \"target\": \"ev2\", \"start-note\": \"note3\", \"end-note\": \"note6\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}, \"id\": \"note4\"},\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}, \"id\": \"note5\"},\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}, \"id\": \"note6\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev1\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"id\": \"note1\"},\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}, \"id\": \"note2\"},\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}, \"id\": \"note3\"}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"down\", \"target\": \"ev2\", \"start-note\": \"note1\", \"end-note\": \"note4\"},\r\n                    {\"side\": \"up\", \"target\": \"ev2\", \"start-note\": \"note2\", \"end-note\": \"note5\"},\r\n                    {\"side\": \"up\", \"target\": \"ev2\", \"start-note\": \"note3\", \"end-note\": \"note6\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev2\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 4}, \"id\": \"note4\"},\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}, \"id\": \"note5\"},\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}, \"id\": \"note6\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/slurs-targeting-specific-notes.png",
         "is_featured": false
     }
@@ -5899,7 +5921,7 @@
         "slug": "slurs-incomplete-slurs",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"up\", \"location\": \"outgoing\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ],\r\n                  \"slurs\": [\r\n                    {\"side\": \"up\", \"location\": \"outgoing\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/slurs-incomplete-slurs.png",
         "is_featured": false
     }
@@ -5912,7 +5934,7 @@
         "slug": "parts",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"name\": \"Melody\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"Harmony\",\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\"events\": [\"ev6\", \"ev7\", \"ev8\", \"ev9\"]}\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"name\": \"Melody\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"Harmony\",\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\"events\": [\"ev6\", \"ev7\", \"ev8\", \"ev9\"]}\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev6\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev7\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev8\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ev9\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/parts.png",
         "is_featured": true
     }
@@ -5925,7 +5947,7 @@
         "slug": "repeats",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-start\": {},\r\n        \"repeat-end\": {}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-start\": {},\r\n        \"repeat-end\": {}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/repeats.png",
         "is_featured": false
     }
@@ -5938,7 +5960,7 @@
         "slug": "repeats-implied-start-repeat",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-end\": {}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-end\": {}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/repeats-implied-start-repeat.png",
         "is_featured": false
     }
@@ -5951,7 +5973,7 @@
         "slug": "repeats-more-once-repeated",
         "schema": 1,
         "blurb": "In this example, the measure is to be performed four times (or “repeated three times,” depending on your perspective).",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-end\": {\"times\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-end\": {\"times\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/repeats-more-once-repeated.png",
         "is_featured": false
     }
@@ -5964,7 +5986,7 @@
         "slug": "repeats-alternate-endings-simple",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-start\": {}\r\n      },\r\n      {\r\n        \"repeat-end\": {},\r\n        \"ending\": {\"numbers\": [1], \"duration\": 1}\r\n      },\r\n      {\r\n        \"repeat-end\": {},\r\n        \"ending\": {\"numbers\": [2], \"duration\": 1}\r\n      },\r\n      {\r\n        \"ending\": {\"numbers\": [3], \"duration\": 1, \"open\": true}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"repeat-start\": {}\r\n      },\r\n      {\r\n        \"repeat-end\": {},\r\n        \"ending\": {\"numbers\": [1], \"duration\": 1}\r\n      },\r\n      {\r\n        \"repeat-end\": {},\r\n        \"ending\": {\"numbers\": [2], \"duration\": 1}\r\n      },\r\n      {\r\n        \"ending\": {\"numbers\": [3], \"duration\": 1, \"open\": true}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/repeats-alternate-endings-simple.png",
         "is_featured": false
     }
@@ -5977,7 +5999,7 @@
         "slug": "repeats-alternate-endings-advanced",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 3, \"unit\": 4},\r\n        \"repeat-start\": {}\r\n      },\r\n      {\r\n        \"ending\": {\"numbers\": [1, 2], \"duration\": 2}\r\n      },\r\n      {\r\n        \"repeat-end\": {}\r\n      },\r\n      {\r\n        \"ending\": {\"numbers\": [3], \"duration\": 2, \"open\": true}\r\n      },\r\n      {},\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 3, \"unit\": 4},\r\n        \"repeat-start\": {}\r\n      },\r\n      {\r\n        \"ending\": {\"numbers\": [1, 2], \"duration\": 2}\r\n      },\r\n      {\r\n        \"repeat-end\": {}\r\n      },\r\n      {\r\n        \"ending\": {\"numbers\": [3], \"duration\": 2, \"open\": true}\r\n      },\r\n      {},\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/repeats-alternate-endings-advanced.png",
         "is_featured": false
     }
@@ -5990,7 +6012,7 @@
         "slug": "jumps-dal-segno",
         "schema": 1,
         "blurb": "In this example, the bars are to be performed in this order: 1, 2, 3, 4, 5, 2, 3, 4, 5.",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {\r\n        \"segno\": {\"location\": \"0\"}\r\n      },\r\n      {},\r\n      {},\r\n      {\r\n        \"jump\": {\"type\": \"segno\", \"location\": \"1\"}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {\r\n        \"segno\": {\"location\": \"0\"}\r\n      },\r\n      {},\r\n      {},\r\n      {\r\n        \"jump\": {\"type\": \"segno\", \"location\": \"1\"}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/jumps-dal-segno.png",
         "is_featured": false
     }
@@ -6003,7 +6025,7 @@
         "slug": "jumps-ds-al-fine",
         "schema": 1,
         "blurb": "In this example, the bars are to be performed in this order: 1, 2, 3, 4, 5, 2, 3.",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {\r\n        \"segno\": {\"location\": \"0\"}\r\n      },\r\n      {\r\n        \"fine\": {\"location\": \"1\"}\r\n      },\r\n      {},\r\n      {\r\n        \"jump\": {\"type\": \"dsalfine\", \"location\": \"1\"}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {\r\n        \"segno\": {\"location\": \"0\"}\r\n      },\r\n      {\r\n        \"fine\": {\"location\": \"1\"}\r\n      },\r\n      {},\r\n      {\r\n        \"jump\": {\"type\": \"dsalfine\", \"location\": \"1\"}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/jumps-ds-al-fine.png",
         "is_featured": false
     }
@@ -6016,7 +6038,7 @@
         "slug": "grace-note",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/grace-note.png",
         "is_featured": false
     }
@@ -6042,7 +6064,7 @@
         "slug": "grace-notes-beamed",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n              \"events\": [\"grace1\", \"grace2\"]\r\n            },\r\n            {\r\n              \"events\": [\"grace3\", \"grace4\", \"grace5\"]\r\n            },\r\n            {\r\n              \"events\": [\"grace6\", \"grace7\", \"grace8\", \"grace9\"]\r\n            }\r\n          ],\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"id\": \"grace1\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace2\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"id\": \"grace3\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace4\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace5\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"id\": \"grace6\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace7\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace8\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace9\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n  \"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"beams\": [\r\n            {\r\n              \"events\": [\"grace1\", \"grace2\"]\r\n            },\r\n            {\r\n              \"events\": [\"grace3\", \"grace4\", \"grace5\"]\r\n            },\r\n            {\r\n              \"events\": [\"grace6\", \"grace7\", \"grace8\", \"grace9\"]\r\n            }\r\n          ],\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"id\": \"grace1\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace2\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"id\": \"grace3\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace4\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace5\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"grace\",\r\n                  \"content\": [\r\n                    {\r\n                      \"id\": \"grace6\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"B\", \"octave\": 4}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace7\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace8\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                      ]\r\n                    },\r\n                    {\r\n                      \"id\": \"grace9\",\r\n                      \"type\": \"event\",\r\n                      \"duration\": {\"base\": \"eighth\"},\r\n                      \"notes\": [\r\n                        {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                      ]\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/beams-grace-notes.png",
         "is_featured": false
     }
@@ -6055,7 +6077,7 @@
         "slug": "tempo-markings",
         "schema": 1,
         "blurb": "",
-        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"tempos\": [\r\n          {\"value\": {\"base\": \"quarter\"}, \"bpm\": 200}\r\n        ]\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4},\r\n        \"tempos\": [\r\n          {\"value\": {\"base\": \"quarter\"}, \"bpm\": 200}\r\n        ]\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/tempo-marking.png",
         "is_featured": false
     }
@@ -6068,7 +6090,7 @@
         "slug": "multiple-layouts",
         "schema": 1,
         "blurb": "In this image, you see three different representations of the same underlying SATB music — one with four separate staves, one with two staves (using multiple voices) and one with two staves (using notes combined into chords).\r\n\r\nThis can be encoded entirely within a single MNX document. The underlying music (the notes, barlines, etc.) is encoded only once, within the <global> and <part> elements. But there are three separate <score> elements — one for each visual representation of the music.\r\n\r\nA <score> references a particular <layout>. The <layout> element is where the style information is contained: which parts, in which order.",
-        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"id\": \"soprano\",\r\n      \"name\": \"Soprano\",\r\n      \"short-name\": \"S\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"alto\",\r\n      \"name\": \"Alto\",\r\n      \"short-name\": \"A\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"tenor\",\r\n      \"name\": \"Tenor\",\r\n      \"short-name\": \"T\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"bass\",\r\n      \"name\": \"Bass\",\r\n      \"short-name\": \"B\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"F\", \"line\": 4},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"layouts\": [\r\n    {\r\n      \"id\": \"Choral4Staff\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"alto\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"bass\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"Choral2StaffStemSplit\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"SA\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\", \"stem\": \"up\"},\r\n                {\"part\": \"alto\", \"stem\": \"down\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"TB\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\", \"stem\": \"up\"},\r\n                {\"part\": \"bass\", \"stem\": \"down\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"Choral2StaffChorded\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"SA\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\"},\r\n                {\"part\": \"alto\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"TB\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\"},\r\n                {\"part\": \"bass\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"Choral2StaffMenSplit\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"SA\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\"},\r\n                {\"part\": \"alto\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"TB\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\", \"stem\": \"up\"},\r\n                {\"part\": \"bass\", \"stem\": \"down\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"scores\": [\r\n    {\r\n      \"name\": \"FourStaff\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\"layout\": \"Choral4Staff\", \"measure\": 1}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"TwoStaffSplit\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\"layout\": \"Choral2StaffStemSplit\", \"measure\": 1}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"TwoStaffChord\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\r\n              \"layout\": \"Choral2StaffChorded\",\r\n              \"measure\": 1,\r\n              \"layout-changes\": [\r\n                {\"layout\": \"Choral2StaffMenSplit\", \"location\": \"2\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"id\": \"soprano\",\r\n      \"name\": \"Soprano\",\r\n      \"short-name\": \"S\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"alto\",\r\n      \"name\": \"Alto\",\r\n      \"short-name\": \"A\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"tenor\",\r\n      \"name\": \"Tenor\",\r\n      \"short-name\": \"T\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"bass\",\r\n      \"name\": \"Bass\",\r\n      \"short-name\": \"B\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"F\", \"line\": 4}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"A\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 3}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"F\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 3}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"layouts\": [\r\n    {\r\n      \"id\": \"Choral4Staff\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"alto\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"labelref\": \"name\",\r\n              \"sources\": [\r\n                {\"part\": \"bass\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"Choral2StaffStemSplit\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"SA\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\", \"stem\": \"up\"},\r\n                {\"part\": \"alto\", \"stem\": \"down\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"TB\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\", \"stem\": \"up\"},\r\n                {\"part\": \"bass\", \"stem\": \"down\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"Choral2StaffChorded\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"SA\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\"},\r\n                {\"part\": \"alto\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"TB\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\"},\r\n                {\"part\": \"bass\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"Choral2StaffMenSplit\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"bracket\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"SA\",\r\n              \"sources\": [\r\n                {\"part\": \"soprano\"},\r\n                {\"part\": \"alto\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"label\": \"TB\",\r\n              \"sources\": [\r\n                {\"part\": \"tenor\", \"stem\": \"up\"},\r\n                {\"part\": \"bass\", \"stem\": \"down\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"scores\": [\r\n    {\r\n      \"name\": \"FourStaff\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\"layout\": \"Choral4Staff\", \"measure\": 1}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"TwoStaffSplit\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\"layout\": \"Choral2StaffStemSplit\", \"measure\": 1}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"TwoStaffChord\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\r\n              \"layout\": \"Choral2StaffChorded\",\r\n              \"measure\": 1,\r\n              \"layout-changes\": [\r\n                {\"layout\": \"Choral2StaffMenSplit\", \"location\": \"2\"}\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/multiple-layouts.png",
         "is_featured": true
     }
@@ -6094,7 +6116,7 @@
         "slug": "organ-layout",
         "schema": 1,
         "blurb": "Note only the music in the first measure is encoded here.",
-        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"key\": {\"fifths\": -3},\r\n        \"time\": {\"count\": 3, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"id\": \"organ\",\r\n      \"staves\": 3,\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"staff\": 1,\r\n              \"voice\": \"Main\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"main1\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"main2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"F\", \"octave\": 4, \"alter\": 1},\r\n                      \"accidentalDisplay\": {\"show\": true}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"main3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"A\", \"octave\": 4},\r\n                      \"accidentalDisplay\": {\"show\": true}\r\n                    }\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"staff\": 1,\r\n              \"voice\": \"Oberwerk\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ober1\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ober2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"A\", \"octave\": 3},\r\n                      \"accidentalDisplay\": {\"show\": true}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ober3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"staff\": 2,\r\n              \"voice\": \"Hauptwerk\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"staff\": 3,\r\n              \"voice\": \"Pedal\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 3, \"alter\": -1}, \"tied\": {\"target\": \"pedNote2\"}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"layouts\": [\r\n    {\r\n      \"id\": \"organ3Stave\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"brace\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"staff\": 1}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"staff\": 2}\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"organ\", \"staff\": 3}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"organ3StaveSplitOber\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"voice\": \"Main\", \"stem\": \"up\"},\r\n                {\"part\": \"organ\", \"voice\": \"Oberwerk\", \"stem\": \"down\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"voice\": \"Hauptwerk\"}\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"organ\", \"staff\": 3}\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"scores\": [\r\n    {\r\n      \"name\": \"defaultScore\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\"layout\": \"organ3stave\", \"measure\": 1, \"layout-changes\": [{\"layout\": \"organ3StaveSplitOber\", \"location\": \"1:3/8\"}]},\r\n            {\"layout\": \"organ3StaveSplitOber\", \"measure\": 6}\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"key\": {\"fifths\": -3},\r\n        \"time\": {\"count\": 3, \"unit\": 4}\r\n      }\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"id\": \"organ\",\r\n      \"staves\": 3,\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"staff\": 1,\r\n              \"voice\": \"Main\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"main1\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 4}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"main2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"F\", \"octave\": 4, \"alter\": 1},\r\n                      \"accidentalDisplay\": {\"show\": true}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"main3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"A\", \"octave\": 4},\r\n                      \"accidentalDisplay\": {\"show\": true}\r\n                    }\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"staff\": 1,\r\n              \"voice\": \"Oberwerk\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"rest\": {}\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ober1\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"B\", \"octave\": 3, \"alter\": -1}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ober2\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\r\n                      \"pitch\": {\"step\": \"A\", \"octave\": 3},\r\n                      \"accidentalDisplay\": {\"show\": true}\r\n                    }\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"id\": \"ober3\",\r\n                  \"duration\": {\"base\": \"eighth\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 4}}\r\n                  ]\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"staff\": 2,\r\n              \"voice\": \"Hauptwerk\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            },\r\n            {\r\n              \"staff\": 3,\r\n              \"voice\": \"Pedal\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\", \"dots\": 1},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 3, \"alter\": -1}, \"tied\": {\"target\": \"pedNote2\"}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"layouts\": [\r\n    {\r\n      \"id\": \"organ3Stave\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"symbol\": \"brace\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"staff\": 1}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"staff\": 2}\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"organ\", \"staff\": 3}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"organ3StaveSplitOber\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"group\",\r\n          \"content\": [\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"voice\": \"Main\", \"stem\": \"up\"},\r\n                {\"part\": \"organ\", \"voice\": \"Oberwerk\", \"stem\": \"down\"}\r\n              ]\r\n            },\r\n            {\r\n              \"type\": \"staff\",\r\n              \"sources\": [\r\n                {\"part\": \"organ\", \"voice\": \"Hauptwerk\"}\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"organ\", \"staff\": 3}\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"scores\": [\r\n    {\r\n      \"name\": \"defaultScore\",\r\n      \"pages\": [\r\n        {\r\n          \"systems\": [\r\n            {\"layout\": \"organ3stave\", \"measure\": 1, \"layout-changes\": [{\"layout\": \"organ3StaveSplitOber\", \"location\": \"1:3/8\"}]},\r\n            {\"layout\": \"organ3StaveSplitOber\", \"measure\": 6}\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/organ-layout.png",
         "is_featured": false
     }
@@ -6107,7 +6129,7 @@
         "slug": "style-class-basic",
         "schema": 1,
         "blurb": "This document defines a style class called \"emphasized\". Any element with class=\"emphasized\" will be colored blue.",
-        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ],\r\n    \"styles\": [\r\n      {\"selector\": \".emphasized\", \"color\": \"#0080FF\"}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"class\": \"emphasized\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}, \"class\": \"emphasized\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ],\r\n    \"styles\": [\r\n      {\"selector\": \".emphasized\", \"color\": \"#0080FF\"}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}, \"class\": \"emphasized\"}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}, \"class\": \"emphasized\"}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/style_class_simple.png",
         "is_featured": false
     }
@@ -6120,7 +6142,7 @@
         "slug": "style-element-basic",
         "schema": 1,
         "blurb": "This document contains a <style> element that effectively says \"color every <note> element blue.\" Because the <style> element lives within <global>, the rule applies to the entire document.",
-        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ],\r\n    \"styles\": [\r\n      {\"selector\": \"note\", \"color\": \"#0080FF\"}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      }\r\n    ],\r\n    \"styles\": [\r\n      {\"selector\": \"note\", \"color\": \"#0080FF\"}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 6}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/style_element_simple.png",
         "is_featured": false
     }
@@ -6133,7 +6155,7 @@
         "slug": "multimeasure-rests",
         "schema": 1,
         "blurb": "This example document contains three views of the same underlying music: a \"full score\" plus two parts as intended for individual musicians. In MNX, these are represented by three separate <score> elements.\r\n\r\nMultimeasure rests are tied to a particular <score>. They live within the <multimeasure-rests> element, and each rest defines its starting measure number and how long the rest lasts.",
-        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {},\r\n      {},\r\n      {},\r\n      {},\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"id\": \"PartA\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"PartB\",\r\n      \"measures\": [\r\n        {\r\n          \"content\": [\r\n            {\"type\": \"clef\", \"sign\": \"G\", \"line\": 2},\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"content\": [\r\n            {\r\n              \"type\": \"sequence\",\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"layouts\": [\r\n    {\r\n      \"id\": \"PartAAlone\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"PartA\"}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"PartBAlone\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"PartB\"}\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"scores\": [\r\n    {\r\n      \"name\": \"Full score\",\r\n      \"pages\": [\r\n        {\"systems\": [\r\n          {\"measure\": 1},\r\n          {\"measure\": 5}\r\n        ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"Part A\",\r\n      \"layout\": \"PartAAlone\",\r\n      \"multimeasure-rests\": [\r\n        {\"start\": 3, \"duration\": 2}\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"Part B\",\r\n      \"layout\": \"PartBAlone\",\r\n      \"multimeasure-rests\": [\r\n        {\"start\": 1, \"duration\": 2},\r\n        {\"start\": 5, \"duration\": 2}\r\n      ]\r\n    }\r\n  ]\r\n}",
+        "document": "{\r\n\"mnx\": {\"version\": 1},\r\n  \"global\": {\r\n    \"measures\": [\r\n      {\r\n        \"barline\": {\"type\": \"regular\"},\r\n        \"time\": {\"count\": 4, \"unit\": 4}\r\n      },\r\n      {},\r\n      {},\r\n      {},\r\n      {},\r\n      {},\r\n      {}\r\n    ]\r\n  },\r\n  \"parts\": [\r\n    {\r\n      \"id\": \"PartA\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"G\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"PartB\",\r\n      \"measures\": [\r\n        {\r\n          \"clefs\": [\r\n            {\"clef\": {\"sign\": \"G\", \"line\": 2}}\r\n          ],\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"E\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"quarter\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"D\", \"octave\": 5}}\r\n                  ]\r\n                },\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"half\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"rest\": {}\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        },\r\n        {\r\n          \"sequences\": [\r\n            {\r\n              \"content\": [\r\n                {\r\n                  \"type\": \"event\",\r\n                  \"duration\": {\"base\": \"whole\"},\r\n                  \"notes\": [\r\n                    {\"pitch\": {\"step\": \"C\", \"octave\": 5}}\r\n                  ]\r\n                }\r\n              ]\r\n            }\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"layouts\": [\r\n    {\r\n      \"id\": \"PartAAlone\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"PartA\"}\r\n          ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"id\": \"PartBAlone\",\r\n      \"content\": [\r\n        {\r\n          \"type\": \"staff\",\r\n          \"sources\": [\r\n            {\"part\": \"PartB\"}\r\n          ]\r\n        }\r\n      ]\r\n    }\r\n  ],\r\n  \"scores\": [\r\n    {\r\n      \"name\": \"Full score\",\r\n      \"pages\": [\r\n        {\"systems\": [\r\n          {\"measure\": 1},\r\n          {\"measure\": 5}\r\n        ]\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"Part A\",\r\n      \"layout\": \"PartAAlone\",\r\n      \"multimeasure-rests\": [\r\n        {\"start\": 3, \"duration\": 2}\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"Part B\",\r\n      \"layout\": \"PartBAlone\",\r\n      \"multimeasure-rests\": [\r\n        {\"start\": 1, \"duration\": 2},\r\n        {\"start\": 5, \"duration\": 2}\r\n      ]\r\n    }\r\n  ]\r\n}",
         "image_url": "/static/examples/multimeasure-rests.png",
         "is_featured": false
     }
@@ -6512,14 +6534,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 10,
-    "fields": {
-        "example": 1,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 11,
     "fields": {
         "example": 1,
@@ -6532,14 +6546,6 @@
     "fields": {
         "example": 1,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 13,
-    "fields": {
-        "example": 1,
-        "json_object": 24
     }
 },
 {
@@ -6632,14 +6638,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 27,
-    "fields": {
-        "example": 2,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 28,
     "fields": {
         "example": 2,
@@ -6652,14 +6650,6 @@
     "fields": {
         "example": 2,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 30,
-    "fields": {
-        "example": 2,
-        "json_object": 24
     }
 },
 {
@@ -6776,14 +6766,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 47,
-    "fields": {
-        "example": 3,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 48,
     "fields": {
         "example": 3,
@@ -6796,14 +6778,6 @@
     "fields": {
         "example": 3,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 50,
-    "fields": {
-        "example": 3,
-        "json_object": 24
     }
 },
 {
@@ -6912,14 +6886,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 66,
-    "fields": {
-        "example": 4,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 67,
     "fields": {
         "example": 4,
@@ -6932,14 +6898,6 @@
     "fields": {
         "example": 4,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 69,
-    "fields": {
-        "example": 4,
-        "json_object": 24
     }
 },
 {
@@ -7048,14 +7006,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 85,
-    "fields": {
-        "example": 5,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 86,
     "fields": {
         "example": 5,
@@ -7068,14 +7018,6 @@
     "fields": {
         "example": 5,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 88,
-    "fields": {
-        "example": 5,
-        "json_object": 24
     }
 },
 {
@@ -7184,14 +7126,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 104,
-    "fields": {
-        "example": 6,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 105,
     "fields": {
         "example": 6,
@@ -7204,14 +7138,6 @@
     "fields": {
         "example": 6,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 107,
-    "fields": {
-        "example": 6,
-        "json_object": 24
     }
 },
 {
@@ -7304,14 +7230,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 122,
-    "fields": {
-        "example": 7,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 123,
     "fields": {
         "example": 7,
@@ -7324,14 +7242,6 @@
     "fields": {
         "example": 7,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 125,
-    "fields": {
-        "example": 7,
-        "json_object": 24
     }
 },
 {
@@ -7424,14 +7334,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 139,
-    "fields": {
-        "example": 8,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 140,
     "fields": {
         "example": 8,
@@ -7444,14 +7346,6 @@
     "fields": {
         "example": 8,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 142,
-    "fields": {
-        "example": 8,
-        "json_object": 24
     }
 },
 {
@@ -7544,14 +7438,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 156,
-    "fields": {
-        "example": 9,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 157,
     "fields": {
         "example": 9,
@@ -7564,14 +7450,6 @@
     "fields": {
         "example": 9,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 159,
-    "fields": {
-        "example": 9,
-        "json_object": 24
     }
 },
 {
@@ -7688,14 +7566,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 176,
-    "fields": {
-        "example": 10,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 177,
     "fields": {
         "example": 10,
@@ -7708,14 +7578,6 @@
     "fields": {
         "example": 10,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 179,
-    "fields": {
-        "example": 10,
-        "json_object": 24
     }
 },
 {
@@ -7832,14 +7694,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 196,
-    "fields": {
-        "example": 11,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 197,
     "fields": {
         "example": 11,
@@ -7852,14 +7706,6 @@
     "fields": {
         "example": 11,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 199,
-    "fields": {
-        "example": 11,
-        "json_object": 24
     }
 },
 {
@@ -7968,14 +7814,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 215,
-    "fields": {
-        "example": 12,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 216,
     "fields": {
         "example": 12,
@@ -7988,14 +7826,6 @@
     "fields": {
         "example": 12,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 218,
-    "fields": {
-        "example": 12,
-        "json_object": 24
     }
 },
 {
@@ -8112,14 +7942,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 236,
-    "fields": {
-        "example": 13,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 237,
     "fields": {
         "example": 13,
@@ -8132,14 +7954,6 @@
     "fields": {
         "example": 13,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 239,
-    "fields": {
-        "example": 13,
-        "json_object": 24
     }
 },
 {
@@ -8400,14 +8214,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 274,
-    "fields": {
-        "example": 14,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 275,
     "fields": {
         "example": 14,
@@ -8420,14 +8226,6 @@
     "fields": {
         "example": 14,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 277,
-    "fields": {
-        "example": 14,
-        "json_object": 24
     }
 },
 {
@@ -8568,14 +8366,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 297,
-    "fields": {
-        "example": 15,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 298,
     "fields": {
         "example": 15,
@@ -8588,14 +8378,6 @@
     "fields": {
         "example": 15,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 300,
-    "fields": {
-        "example": 15,
-        "json_object": 24
     }
 },
 {
@@ -8696,14 +8478,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 315,
-    "fields": {
-        "example": 16,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 316,
     "fields": {
         "example": 16,
@@ -8716,14 +8490,6 @@
     "fields": {
         "example": 16,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 318,
-    "fields": {
-        "example": 16,
-        "json_object": 24
     }
 },
 {
@@ -8856,14 +8622,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 337,
-    "fields": {
-        "example": 17,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 338,
     "fields": {
         "example": 17,
@@ -8876,14 +8634,6 @@
     "fields": {
         "example": 17,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 340,
-    "fields": {
-        "example": 17,
-        "json_object": 24
     }
 },
 {
@@ -9008,14 +8758,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 358,
-    "fields": {
-        "example": 18,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 359,
     "fields": {
         "example": 18,
@@ -9028,14 +8770,6 @@
     "fields": {
         "example": 18,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 361,
-    "fields": {
-        "example": 18,
-        "json_object": 24
     }
 },
 {
@@ -9160,14 +8894,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 379,
-    "fields": {
-        "example": 19,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 380,
     "fields": {
         "example": 19,
@@ -9180,14 +8906,6 @@
     "fields": {
         "example": 19,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 382,
-    "fields": {
-        "example": 19,
-        "json_object": 24
     }
 },
 {
@@ -9312,14 +9030,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 400,
-    "fields": {
-        "example": 20,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 401,
     "fields": {
         "example": 20,
@@ -9332,14 +9042,6 @@
     "fields": {
         "example": 20,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 403,
-    "fields": {
-        "example": 20,
-        "json_object": 24
     }
 },
 {
@@ -9464,14 +9166,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 421,
-    "fields": {
-        "example": 21,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 422,
     "fields": {
         "example": 21,
@@ -9484,14 +9178,6 @@
     "fields": {
         "example": 21,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 424,
-    "fields": {
-        "example": 21,
-        "json_object": 24
     }
 },
 {
@@ -9616,14 +9302,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 442,
-    "fields": {
-        "example": 22,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 443,
     "fields": {
         "example": 22,
@@ -9636,14 +9314,6 @@
     "fields": {
         "example": 22,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 445,
-    "fields": {
-        "example": 22,
-        "json_object": 24
     }
 },
 {
@@ -9744,14 +9414,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 460,
-    "fields": {
-        "example": 23,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 461,
     "fields": {
         "example": 23,
@@ -9764,14 +9426,6 @@
     "fields": {
         "example": 23,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 463,
-    "fields": {
-        "example": 23,
-        "json_object": 24
     }
 },
 {
@@ -9880,14 +9534,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 479,
-    "fields": {
-        "example": 24,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 480,
     "fields": {
         "example": 24,
@@ -9900,14 +9546,6 @@
     "fields": {
         "example": 24,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 482,
-    "fields": {
-        "example": 24,
-        "json_object": 24
     }
 },
 {
@@ -10016,14 +9654,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 498,
-    "fields": {
-        "example": 25,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 499,
     "fields": {
         "example": 25,
@@ -10036,14 +9666,6 @@
     "fields": {
         "example": 25,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 501,
-    "fields": {
-        "example": 25,
-        "json_object": 24
     }
 },
 {
@@ -10216,14 +9838,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 525,
-    "fields": {
-        "example": 26,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 526,
     "fields": {
         "example": 26,
@@ -10236,14 +9850,6 @@
     "fields": {
         "example": 26,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 528,
-    "fields": {
-        "example": 26,
-        "json_object": 24
     }
 },
 {
@@ -10344,50 +9950,10 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 543,
-    "fields": {
-        "example": 27,
-        "json_object": 19
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 544,
     "fields": {
         "example": 27,
         "json_object": 20
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 545,
-    "fields": {
-        "example": 27,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 546,
-    "fields": {
-        "example": 27,
-        "json_object": 22
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 547,
-    "fields": {
-        "example": 27,
-        "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 548,
-    "fields": {
-        "example": 27,
-        "json_object": 24
     }
 },
 {
@@ -10512,14 +10078,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 566,
-    "fields": {
-        "example": 28,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 567,
     "fields": {
         "example": 28,
@@ -10532,14 +10090,6 @@
     "fields": {
         "example": 28,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 569,
-    "fields": {
-        "example": 28,
-        "json_object": 24
     }
 },
 {
@@ -10648,14 +10198,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 585,
-    "fields": {
-        "example": 29,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 586,
     "fields": {
         "example": 29,
@@ -10668,14 +10210,6 @@
     "fields": {
         "example": 29,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 588,
-    "fields": {
-        "example": 29,
-        "json_object": 24
     }
 },
 {
@@ -10896,14 +10430,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 618,
-    "fields": {
-        "example": 31,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 619,
     "fields": {
         "example": 31,
@@ -10916,14 +10442,6 @@
     "fields": {
         "example": 31,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 621,
-    "fields": {
-        "example": 31,
-        "json_object": 24
     }
 },
 {
@@ -11056,14 +10574,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 640,
-    "fields": {
-        "example": 32,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 641,
     "fields": {
         "example": 32,
@@ -11076,14 +10586,6 @@
     "fields": {
         "example": 32,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 643,
-    "fields": {
-        "example": 32,
-        "json_object": 24
     }
 },
 {
@@ -11192,14 +10694,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 659,
-    "fields": {
-        "example": 33,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 660,
     "fields": {
         "example": 33,
@@ -11212,14 +10706,6 @@
     "fields": {
         "example": 33,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 662,
-    "fields": {
-        "example": 33,
-        "json_object": 24
     }
 },
 {
@@ -11632,14 +11118,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 718,
-    "fields": {
-        "example": 36,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 719,
     "fields": {
         "example": 36,
@@ -11652,14 +11130,6 @@
     "fields": {
         "example": 36,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 721,
-    "fields": {
-        "example": 36,
-        "json_object": 24
     }
 },
 {
@@ -11800,14 +11270,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 741,
-    "fields": {
-        "example": 37,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 742,
     "fields": {
         "example": 37,
@@ -11820,14 +11282,6 @@
     "fields": {
         "example": 37,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 744,
-    "fields": {
-        "example": 37,
-        "json_object": 24
     }
 },
 {
@@ -11976,14 +11430,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 765,
-    "fields": {
-        "example": 38,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 766,
     "fields": {
         "example": 38,
@@ -11996,14 +11442,6 @@
     "fields": {
         "example": 38,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 769,
-    "fields": {
-        "example": 38,
-        "json_object": 24
     }
 },
 {
@@ -12160,14 +11598,6 @@
 },
 {
     "model": "spec.exampledocumentobject",
-    "pk": 791,
-    "fields": {
-        "example": 35,
-        "json_object": 21
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
     "pk": 792,
     "fields": {
         "example": 35,
@@ -12180,14 +11610,6 @@
     "fields": {
         "example": 35,
         "json_object": 23
-    }
-},
-{
-    "model": "spec.exampledocumentobject",
-    "pk": 794,
-    "fields": {
-        "example": 35,
-        "json_object": 24
     }
 },
 {
@@ -15052,6 +14474,326 @@
     "fields": {
         "example": 35,
         "json_object": 112
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1156,
+    "fields": {
+        "example": 1,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1157,
+    "fields": {
+        "example": 2,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1158,
+    "fields": {
+        "example": 3,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1159,
+    "fields": {
+        "example": 4,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1160,
+    "fields": {
+        "example": 5,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1161,
+    "fields": {
+        "example": 6,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1162,
+    "fields": {
+        "example": 7,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1163,
+    "fields": {
+        "example": 8,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1164,
+    "fields": {
+        "example": 9,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1165,
+    "fields": {
+        "example": 10,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1166,
+    "fields": {
+        "example": 11,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1167,
+    "fields": {
+        "example": 12,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1168,
+    "fields": {
+        "example": 13,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1169,
+    "fields": {
+        "example": 14,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1170,
+    "fields": {
+        "example": 15,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1171,
+    "fields": {
+        "example": 16,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1172,
+    "fields": {
+        "example": 17,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1173,
+    "fields": {
+        "example": 18,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1174,
+    "fields": {
+        "example": 19,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1175,
+    "fields": {
+        "example": 20,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1176,
+    "fields": {
+        "example": 21,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1177,
+    "fields": {
+        "example": 22,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1178,
+    "fields": {
+        "example": 23,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1179,
+    "fields": {
+        "example": 24,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1180,
+    "fields": {
+        "example": 25,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1181,
+    "fields": {
+        "example": 26,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1182,
+    "fields": {
+        "example": 27,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1183,
+    "fields": {
+        "example": 27,
+        "json_object": 19
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1184,
+    "fields": {
+        "example": 27,
+        "json_object": 22
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1185,
+    "fields": {
+        "example": 27,
+        "json_object": 23
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1186,
+    "fields": {
+        "example": 28,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1187,
+    "fields": {
+        "example": 29,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1188,
+    "fields": {
+        "example": 31,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1189,
+    "fields": {
+        "example": 32,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1190,
+    "fields": {
+        "example": 33,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1191,
+    "fields": {
+        "example": 35,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1192,
+    "fields": {
+        "example": 36,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1193,
+    "fields": {
+        "example": 36,
+        "json_object": 108
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1194,
+    "fields": {
+        "example": 37,
+        "json_object": 139
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1195,
+    "fields": {
+        "example": 38,
+        "json_object": 139
     }
 },
 {

--- a/docs/comparisons/musicxml/index.html
+++ b/docs/comparisons/musicxml/index.html
@@ -166,14 +166,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -332,14 +334,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -402,9 +406,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -570,14 +573,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -783,14 +788,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -853,9 +860,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -918,9 +924,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1131,14 +1136,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1203,9 +1210,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1227,9 +1233,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1295,9 +1300,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1472,14 +1476,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1546,9 +1552,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1603,9 +1608,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1754,14 +1758,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -1979,14 +1985,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -2056,9 +2064,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -2333,14 +2340,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -2492,9 +2501,8 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev9"</a>,
@@ -2978,14 +2986,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -3461,14 +3471,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -3755,14 +3767,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -4002,14 +4016,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -4060,9 +4076,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev5"</a>,
@@ -4368,14 +4383,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/tuplet/">"type"</a>: "tuplet",
@@ -4517,9 +4534,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/tuplet/">"type"</a>: "tuplet",
@@ -4795,14 +4811,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -4835,7 +4853,6 @@
                      ]
                   },
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -4898,9 +4915,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -4919,7 +4935,6 @@
                      ]
                   },
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -5102,14 +5117,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -5163,9 +5180,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -5364,14 +5380,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -5444,9 +5462,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev5"</a>,
@@ -5666,14 +5683,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -5913,14 +5932,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"id"</a>: <a class="tag" href="../../mnx-reference/objects/id/">"ev1"</a>,
@@ -6102,14 +6123,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6381,14 +6404,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6451,9 +6476,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6531,14 +6555,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6612,9 +6638,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6747,14 +6772,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6858,14 +6885,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -6971,14 +7000,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7164,14 +7195,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7192,9 +7225,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7215,9 +7247,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7238,9 +7269,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7448,14 +7478,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7477,9 +7509,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7501,9 +7532,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7538,9 +7568,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7562,9 +7591,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7599,9 +7627,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7768,14 +7795,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7796,9 +7825,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7819,9 +7847,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7842,9 +7869,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -7865,9 +7891,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -8043,14 +8068,16 @@
       {
          <a class="tag" href="../../mnx-reference/objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
-                     <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../mnx-reference/objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"line"</a>: <a class="tag" href="../../mnx-reference/objects/clef-line/">2</a>,
+                        <a class="tag" href="../../mnx-reference/objects/clef/">"sign"</a>: <a class="tag" href="../../mnx-reference/objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -8071,9 +8098,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -8094,9 +8120,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -8117,9 +8142,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",
@@ -8140,9 +8164,8 @@
                ]
             },
             {
-               <a class="tag" href="../../mnx-reference/objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../mnx-reference/objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../mnx-reference/objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../mnx-reference/objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../mnx-reference/objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/accidentals/index.html
+++ b/docs/mnx-reference/examples/accidentals/index.html
@@ -87,14 +87,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -161,9 +163,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -218,9 +219,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/beam-hooks/index.html
+++ b/docs/mnx-reference/examples/beam-hooks/index.html
@@ -135,14 +135,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,

--- a/docs/mnx-reference/examples/beams-across-barlines/index.html
+++ b/docs/mnx-reference/examples/beams-across-barlines/index.html
@@ -93,14 +93,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -151,9 +153,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev5"</a>,

--- a/docs/mnx-reference/examples/beams-inner-grace-notes/index.html
+++ b/docs/mnx-reference/examples/beams-inner-grace-notes/index.html
@@ -92,14 +92,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,

--- a/docs/mnx-reference/examples/beams-secondary-beam-breaks/index.html
+++ b/docs/mnx-reference/examples/beams-secondary-beam-breaks/index.html
@@ -192,14 +192,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,

--- a/docs/mnx-reference/examples/beams/index.html
+++ b/docs/mnx-reference/examples/beams/index.html
@@ -101,14 +101,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,
@@ -260,9 +262,8 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev9"</a>,

--- a/docs/mnx-reference/examples/dotted-notes/index.html
+++ b/docs/mnx-reference/examples/dotted-notes/index.html
@@ -82,14 +82,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/grace-note/index.html
+++ b/docs/mnx-reference/examples/grace-note/index.html
@@ -80,14 +80,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/grace/">"type"</a>: "grace",

--- a/docs/mnx-reference/examples/grace-notes-beamed/index.html
+++ b/docs/mnx-reference/examples/grace-notes-beamed/index.html
@@ -103,14 +103,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/hello-world/index.html
+++ b/docs/mnx-reference/examples/hello-world/index.html
@@ -87,14 +87,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/jumps-dal-segno/index.html
+++ b/docs/mnx-reference/examples/jumps-dal-segno/index.html
@@ -97,14 +97,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -125,9 +127,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -148,9 +149,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -171,9 +171,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -194,9 +193,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/jumps-ds-al-fine/index.html
+++ b/docs/mnx-reference/examples/jumps-ds-al-fine/index.html
@@ -101,14 +101,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -129,9 +131,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -152,9 +153,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -175,9 +175,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -198,9 +197,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/key-signatures/index.html
+++ b/docs/mnx-reference/examples/key-signatures/index.html
@@ -92,14 +92,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -164,9 +166,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -188,9 +189,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -256,9 +256,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/multimeasure-rests/index.html
+++ b/docs/mnx-reference/examples/multimeasure-rests/index.html
@@ -120,14 +120,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"PartA"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -176,9 +178,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -227,9 +228,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -243,9 +243,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -259,9 +258,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -310,9 +308,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -361,9 +358,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -389,14 +385,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"PartB"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -410,9 +408,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -426,9 +423,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -477,9 +473,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -528,9 +523,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -544,9 +538,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -560,9 +553,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/multiple-layouts/index.html
+++ b/docs/mnx-reference/examples/multiple-layouts/index.html
@@ -244,14 +244,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"soprano"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -314,9 +316,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -372,14 +373,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"alto"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -442,9 +445,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -500,14 +502,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"tenor"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -570,9 +574,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -642,14 +645,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"bass"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">4</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"F"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">4</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"F"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -712,9 +717,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/multiple-voices/index.html
+++ b/docs/mnx-reference/examples/multiple-voices/index.html
@@ -83,14 +83,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -123,7 +125,6 @@
                      ]
                   },
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -186,9 +187,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -207,7 +207,6 @@
                      ]
                   },
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/octave-shifts-8va/index.html
+++ b/docs/mnx-reference/examples/octave-shifts-8va/index.html
@@ -83,14 +83,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -144,9 +146,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/organ-layout/index.html
+++ b/docs/mnx-reference/examples/organ-layout/index.html
@@ -169,14 +169,16 @@
          <a class="tag" href="../../objects/part/">"id"</a>: <a class="tag" href="../../objects/id/">"organ"</a>,
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -249,7 +251,6 @@
                      <a class="tag" href="../../objects/sequence/">"voice"</a>: <a class="tag" href="../../objects/voice-name/">"Main"</a>
                   },
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -319,7 +320,6 @@
                      <a class="tag" href="../../objects/sequence/">"voice"</a>: <a class="tag" href="../../objects/voice-name/">"Oberwerk"</a>
                   },
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -334,7 +334,6 @@
                      <a class="tag" href="../../objects/sequence/">"voice"</a>: <a class="tag" href="../../objects/voice-name/">"Hauptwerk"</a>
                   },
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/parts/index.html
+++ b/docs/mnx-reference/examples/parts/index.html
@@ -83,14 +83,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -153,9 +155,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -233,14 +234,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -314,9 +317,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/repeats-alternate-endings-advanced/index.html
+++ b/docs/mnx-reference/examples/repeats-alternate-endings-advanced/index.html
@@ -106,14 +106,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -135,9 +137,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -159,9 +160,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -196,9 +196,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -220,9 +219,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -257,9 +255,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/repeats-alternate-endings-simple/index.html
+++ b/docs/mnx-reference/examples/repeats-alternate-endings-simple/index.html
@@ -110,14 +110,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -138,9 +140,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -161,9 +162,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -184,9 +184,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/repeats-implied-start-repeat/index.html
+++ b/docs/mnx-reference/examples/repeats-implied-start-repeat/index.html
@@ -83,14 +83,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/repeats-more-once-repeated/index.html
+++ b/docs/mnx-reference/examples/repeats-more-once-repeated/index.html
@@ -87,14 +87,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/repeats/index.html
+++ b/docs/mnx-reference/examples/repeats/index.html
@@ -84,14 +84,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/slurs-chords/index.html
+++ b/docs/mnx-reference/examples/slurs-chords/index.html
@@ -82,14 +82,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,

--- a/docs/mnx-reference/examples/slurs-incomplete-slurs/index.html
+++ b/docs/mnx-reference/examples/slurs-incomplete-slurs/index.html
@@ -82,14 +82,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/slurs-targeting-specific-notes/index.html
+++ b/docs/mnx-reference/examples/slurs-targeting-specific-notes/index.html
@@ -82,14 +82,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,

--- a/docs/mnx-reference/examples/slurs/index.html
+++ b/docs/mnx-reference/examples/slurs/index.html
@@ -83,14 +83,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev1"</a>,
@@ -163,9 +165,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"id"</a>: <a class="tag" href="../../objects/id/">"ev5"</a>,

--- a/docs/mnx-reference/examples/style-class-basic/index.html
+++ b/docs/mnx-reference/examples/style-class-basic/index.html
@@ -91,14 +91,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/style-element-basic/index.html
+++ b/docs/mnx-reference/examples/style-element-basic/index.html
@@ -91,14 +91,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/tempo-markings/index.html
+++ b/docs/mnx-reference/examples/tempo-markings/index.html
@@ -89,14 +89,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -159,9 +161,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/three-note-chord-and-half-rest/index.html
+++ b/docs/mnx-reference/examples/three-note-chord-and-half-rest/index.html
@@ -85,14 +85,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/ties/index.html
+++ b/docs/mnx-reference/examples/ties/index.html
@@ -83,14 +83,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -160,9 +162,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/time-signatures/index.html
+++ b/docs/mnx-reference/examples/time-signatures/index.html
@@ -89,14 +89,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -159,9 +161,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -224,9 +225,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/examples/tuplets/index.html
+++ b/docs/mnx-reference/examples/tuplets/index.html
@@ -92,14 +92,16 @@
                      ]
                   }
                ],
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/tuplet/">"type"</a>: "tuplet",
@@ -241,9 +243,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/tuplet/">"type"</a>: "tuplet",

--- a/docs/mnx-reference/examples/two-bar-c-major-scale/index.html
+++ b/docs/mnx-reference/examples/two-bar-c-major-scale/index.html
@@ -87,14 +87,16 @@
       {
          <a class="tag" href="../../objects/part/">"measures"</a>: [
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"clefs"</a>: [
                   {
-                     <a class="tag" href="../../objects/clef/">"type"</a>: "clef",
-                     <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
-                     <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
-                  },
+                     <a class="tag" href="../../objects/positioned-clef/">"clef"</a>: {
+                        <a class="tag" href="../../objects/clef/">"line"</a>: <a class="tag" href="../../objects/clef-line/">2</a>,
+                        <a class="tag" href="../../objects/clef/">"sign"</a>: <a class="tag" href="../../objects/clef-sign/">"G"</a>
+                     }
+                  }
+               ],
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",
@@ -157,9 +159,8 @@
                ]
             },
             {
-               <a class="tag" href="../../objects/part-measure/">"content"</a>: [
+               <a class="tag" href="../../objects/part-measure/">"sequences"</a>: [
                   {
-                     <a class="tag" href="../../objects/sequence/">"type"</a>: "sequence",
                      <a class="tag" href="../../objects/sequence/">"content"</a>: [
                         {
                            <a class="tag" href="../../objects/event/">"type"</a>: "event",

--- a/docs/mnx-reference/objects/clef/index.html
+++ b/docs/mnx-reference/objects/clef/index.html
@@ -132,17 +132,6 @@
     <td>The clef sign.</td>
 </tr>
 
-<tr>
-    <td><nobr><b>"type"</b></nobr></td>
-    <td>
-        
-            The string <code>"clef"</code>
-        
-    </td>
-    <td>Yes</td>
-    <td></td>
-</tr>
-
 
 </table>
 

--- a/docs/mnx-reference/objects/index.html
+++ b/docs/mnx-reference/objects/index.html
@@ -161,6 +161,8 @@
 
 <li><a href="pitch/">pitch</a></li>
 
+<li><a href="positioned-clef/">positioned clef</a></li>
+
 <li><a href="positive-integer/">positive integer</a></li>
 
 <li><a href="repeat-end/">repeat end</a></li>

--- a/docs/mnx-reference/objects/part-measure/index.html
+++ b/docs/mnx-reference/objects/part-measure/index.html
@@ -83,12 +83,24 @@
 </tr>
 
 <tr>
-    <td><nobr><b>"content"</b></nobr></td>
+    <td><nobr><b>"clefs"</b></nobr></td>
     <td>
         
             An array of
             
-            <a href="../clef/">clef objects</a>, 
+            <a href="../positioned-clef/">positioned clef objects</a>
+            
+        
+    </td>
+    <td>No</td>
+    <td></td>
+</tr>
+
+<tr>
+    <td><nobr><b>"sequences"</b></nobr></td>
+    <td>
+        
+            An array of
             
             <a href="../sequence/">sequence objects</a>
             

--- a/docs/mnx-reference/objects/positioned-clef/index.html
+++ b/docs/mnx-reference/objects/positioned-clef/index.html
@@ -53,6 +53,10 @@
 
 <p>Represents a clef as positioned at a specific location within a measure.</p>
 
+<p>If the position isn't encoded, the position is assumed to be the start of the measure.</p>
+
+<p>Note: This object will eventually include a "position" key, but we haven't yet designed how that will be encoded.</p>
+
 
 
 <h2>Keys:</h2>
@@ -77,18 +81,6 @@
     </td>
     <td>Yes</td>
     <td></td>
-</tr>
-
-<tr>
-    <td><nobr><b>"position"</b></nobr></td>
-    <td>
-        
-            An array of
-            
-        
-    </td>
-    <td>No</td>
-    <td>The clef's position in the measure. If absent, this value is assumed to be [0, 1], the start of the measure.</td>
 </tr>
 
 

--- a/docs/mnx-reference/objects/positioned-clef/index.html
+++ b/docs/mnx-reference/objects/positioned-clef/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>The sequence object | MNX specification</title>
+<title>The positioned clef object | MNX specification</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width">
 <link rel="stylesheet" href="../../../static/styles.css">
@@ -43,19 +43,15 @@
     <a href="../../../">MNX specification</a> &gt;
     <a href="../../">MNX reference</a> &gt;
     <a href="../">Objects</a> &gt;
-    sequence
+    positioned clef
 </p>
 
-<h1>The sequence object</h1>
+<h1>The positioned clef object</h1>
 
 <p><b>Type:</b> Dictionary</p>
 
 
-<p>The sequence object organizes a set of musical events within a measure into a strict temporal <a href="../../../infrastructure/sequence-content/">sequence</a>, accompanied by relevant directions.</p>
-
-<p>To determine the measure position of each event within a sequence, you <a href="../../../infrastructure/sequence-content/">sequence the content</a>, with a starting position <code>0</code> and time modification ratio <code>1</code>.</p>
-
-<p>The content within each sequence supplies the music for a single polyphonic voice within its containing measure, including notes, chords, rests, tuplets and grace notes.</p>
+<p>Represents a clef as positioned at a specific location within a measure.</p>
 
 
 
@@ -73,23 +69,10 @@
 
 
 <tr>
-    <td><nobr><b>"content"</b></nobr></td>
+    <td><nobr><b>"clef"</b></nobr></td>
     <td>
         
-            An array of
-            
-            <a href="../event/">event objects</a>, 
-            
-            <a href="../grace/">grace objects</a>, 
-            
-            <a href="../tuplet/">tuplet objects</a>, 
-            
-            <a href="../octave-shift/">octave shift objects</a>, 
-            
-            <a href="../space/">space objects</a>, 
-            
-            <a href="../dynamic/">dynamic objects</a>
-            
+        <a href="../clef/">clef object</a>
         
     </td>
     <td>Yes</td>
@@ -97,36 +80,15 @@
 </tr>
 
 <tr>
-    <td><nobr><b>"orient"</b></nobr></td>
+    <td><nobr><b>"position"</b></nobr></td>
     <td>
         
-        <a href="../orientation/">orientation object</a>
+            An array of
+            
         
     </td>
     <td>No</td>
-    <td>The default orientation of the content in this sequence. If not provided, the orientation is determined automatically according to the implementation’s rendering rules and may be overridden by descendant elements.</td>
-</tr>
-
-<tr>
-    <td><nobr><b>"staff"</b></nobr></td>
-    <td>
-        
-        <a href="../staff-number/">staff number object</a>
-        
-    </td>
-    <td>No</td>
-    <td>The default staff index of the content in this sequence. If not provided, the orientation is determined automatically according to the implementation’s rendering rules and may be overridden by descendant elements.</td>
-</tr>
-
-<tr>
-    <td><nobr><b>"voice"</b></nobr></td>
-    <td>
-        
-        <a href="../voice-name/">voice name object</a>
-        
-    </td>
-    <td>No</td>
-    <td>A string that identifies the voice to which this sequence belongs. All sequences in a given part having the same value of "voice" belong to the same voice. Within a given measure, no two sequences may share the same value for voice. The value of voice is an opaque identifier that does not supply information from producers to consumers.</td>
+    <td>The clef's position in the measure. If absent, this value is assumed to be [0, 1], the start of the measure.</td>
 </tr>
 
 

--- a/docs/mnx-reference/objects/style-class/index.html
+++ b/docs/mnx-reference/objects/style-class/index.html
@@ -57,6 +57,13 @@ A style class is a string that styleable MNX elements can use to declare they sh
 
 
 
+<h2 id="examples">Examples</h2>
+
+<p>This object is used in the following examples:</p>
+<p>
+    <nobr><a href="../../examples/style-class-basic/">Styling via a class (basic)</a></nobr>
+</p>
+
 
 
     </main>


### PR DESCRIPTION
In my work to update the [mnxconverter](https://github.com/w3c/mnxconverter) to output JSON instead of XML, I realized the current approach of encoding measure contents into a heterogeneous list (containing clefs and sequences) has started to feel awkward. I brought this up in the latest co-chairs meeting ([see here](https://www.w3.org/community/music-notation/2023/09/14/co-chair-meeting-minutes-september-14-2023/)), and the three co-chairs agreed it's worth simplifying the encoding.

This pull request addresses that. The specific changes are:

* In the [part-measure object](https://cdn.githubraw.com/w3c/mnx/sequence-simplification/docs/mnx-reference/objects/part-measure/): instead of a `"contents"` key that contains clefs and sequences, we now use two separate keys, `"clefs"` and `"sequences"`.
* That `"clefs"` key is a list of [positioned clef](https://cdn.githubraw.com/w3c/mnx/sequence-simplification/docs/mnx-reference/objects/positioned-clef/) objects, each of which has a clef and position. The position is currently encoded as a two-element array, where `[1, 4]` would be a quarter note's duration into the measure.
* In a positioned clef, the position is optional. If not provided, the position should be interpreted as zero (i.e., the start of the measure). This is a small nicety to make the common case simpler to encode.
* Clef objects no longer require a `"type": "clef"`, and sequence objects no longer require a `"type": "sequence"`. That's because these two types of objects are no longer used in a heterogeneous context. (I see this as a big win, as the `"type"` thing always felt inelegant!)

I've updated all example documents to use the new syntax. Use [this link](https://cdn.githubraw.com/w3c/mnx/sequence-simplification/docs/mnx-reference/examples/) to view the examples in context of this branch.

Community members, please have a look/think about these changes, and let me know your feedback! Personally I'm feeling very good about it.

One aspect I'd specifically like feedback on is the new "position" type. I used a simple two-element array because it's nice and compact — but a proper object might be a better approach here.