### PR TITLE
Automatic creation of JSON Schema

### DIFF
--- a/docgenerator/data.json
+++ b/docgenerator/data.json
@@ -32,7 +32,7 @@
     "fields": {
         "site_name": "MNX specification",
         "xml_format_name": "MNX",
-        "sidebar_html": "<ul>\r\n<li><a href=\"/\">Home</a></li>\r\n<li><a href=\"/mnx-reference/objects/\">Reference</a>\r\n    <ul>\r\n    <li><a href=\"/mnx-reference/objects/\">Objects</a></li>\r\n    <li><a href=\"/mnx-reference/examples/\">Example documents</a></li>\r\n    </ul>\r\n</li>\r\n<li><a href=\"/comparisons/musicxml/\">MNX and MusicXML</a></li>\r\n</ul>"
+        "sidebar_html": "<ul>\r\n<li><a href=\"/\">Home</a></li>\r\n<li><a href=\"/mnx-reference/objects/\">Reference</a>\r\n    <ul>\r\n    <li><a href=\"/mnx-reference/objects/\">Objects</a></li>\r\n    <li><a href=\"/mnx-reference/examples/\">Example documents</a></li>\r\n    <li><a href=\"/mnx-schema.json\">Raw JSON Schema</a></li>\r\n    </ul>\r\n</li>\r\n<li><a href=\"/comparisons/musicxml/\">MNX and MusicXML</a></li>\r\n</ul>"
     }
 },
 {

--- a/docgenerator/docgenerator/urls.py
+++ b/docgenerator/docgenerator/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('<slug:schema_slug>-reference/examples/<slug:slug>/', views.example_detail, name='example_detail'),
     path('<slug:schema_slug>-reference/objects/', views.json_object_list, name='json_object_list'),
     path('<slug:schema_slug>-reference/objects/<slug:slug>/', views.json_object_detail, name='json_object_detail'),
+    path('<slug:schema_slug>-schema.json', views.json_schema, name='json_schema'),
     path('concepts/', views.concept_list, name='concept_list'),
     path('concepts/<slug:slug>/', views.concept_detail, name='concept_detail'),
     path('comparisons/<slug:slug>/', views.format_comparison_detail, name='format_comparison_detail'),

--- a/docgenerator/spec/management/commands/makesite.py
+++ b/docgenerator/spec/management/commands/makesite.py
@@ -36,6 +36,7 @@ class SiteGenerator:
             self.generate_url(schema.data_types_url())
             if schema.is_json:
                 self.generate_url(schema.json_objects_url())
+                self.generate_view('json_schema', schema.slug)
             else:
                 self.generate_url(schema.elements_url())
                 self.generate_url(schema.element_tree_url())

--- a/docgenerator/spec/utils/jsonschema.py
+++ b/docgenerator/spec/utils/jsonschema.py
@@ -1,0 +1,92 @@
+from spec.models import *
+
+# Each of these types is a native JSONSchema type and also exists as a
+# JSONObject.slug.
+NATIVE_TYPES = set(['boolean'])
+
+def make_json_schema(schema_slug='mnx'):
+    """
+    Creates a JSON schema by looking at the JSONObject information
+    in the database. The result is a Python data structure that, if
+    serialized to JSON, is a correct JSON schema.
+    """
+    # First, add the root object.
+    root_object = JSONObject.objects.filter(
+        schema__slug=schema_slug,
+        name=JSONObject.ROOT_OBJECT_NAME
+    )[0]
+    result = get_schema_for_db_object(root_object)
+    result.update({
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        '$id': 'https://w3c.github.io/mnx/docs/mnx-schema.json',
+        'title': 'MNX document',
+        'description': 'An encoding of Common Western Music Notation.',
+    })
+
+    # Next, add any defs. We do this for any JSONObject that appears as
+    # JSONRelationship.child more than once.
+    defs = {}
+    def_objects = JSONObject.objects.filter(schema__slug=schema_slug)
+    for def_object in def_objects:
+        if def_object.slug not in NATIVE_TYPES and JSONObjectRelationship.objects.filter(child=def_object).count() > 1:
+            defs[def_object.slug] = get_schema_for_db_object(def_object, use_defs=False)
+    if defs:
+        result['$defs'] = defs
+
+    return result
+
+def get_schema_for_db_object(db_object, use_defs=True):
+    """
+    Given a JSONObject instance, returns its JSON schema definition
+    as a Python dictionary.
+    """
+    if db_object.slug in NATIVE_TYPES:
+        return {
+            'type': db_object.slug
+        }
+    if use_defs and JSONObjectRelationship.objects.filter(child=db_object).count() > 1:
+        return {
+            '$ref': f'#/$defs/{db_object.slug}'
+        }
+    object_type = db_object.object_type
+    if object_type == JSONObject.OBJECT_TYPE_DICT:
+        props = dict([(childrel.child_key, get_schema_for_db_object(childrel.child)) for childrel in db_object.get_child_relationships()])
+        required = [childrel.child_key for childrel in db_object.get_child_relationships() if childrel.is_required]
+        result = {
+            'type': 'object',
+            'properties': props,
+            'additionalProperties': False
+        }
+        if required:
+            result['required'] = list(sorted(required))
+        return result
+    elif object_type == JSONObject.OBJECT_TYPE_ARRAY:
+        childrels = db_object.get_child_relationships()
+        if len(childrels) == 1:
+            items = get_schema_for_db_object(childrels[0].child)
+        else:
+            items = {
+                'anyOf': [get_schema_for_db_object(childrel.child) for childrel in childrels],
+            }
+        result = {
+            'type': 'array',
+            'items': items
+        }
+        return result
+    elif object_type == JSONObject.OBJECT_TYPE_NUMBER:
+        return {
+            'type': 'integer'
+        }
+    elif object_type == JSONObject.OBJECT_TYPE_BOOLEAN:
+        return {
+            'type': 'boolean'
+        }
+    elif object_type == JSONObject.OBJECT_TYPE_STRING:
+        return {
+            'type': 'string'
+        }
+    elif object_type == JSONObject.OBJECT_TYPE_LITERAL_STRING:
+        return {
+            'type': 'string',
+            'const': db_object.description
+        }

--- a/docgenerator/spec/views.py
+++ b/docgenerator/spec/views.py
@@ -86,6 +86,13 @@ def json_object_detail(request, schema_slug, slug):
         'examples': ExampleDocumentObject.objects.filter(json_object=json_object).select_related('example').order_by(Lower('example__name')),
     })
 
+def json_schema(request, schema_slug):
+    from spec.utils.jsonschema import make_json_schema
+    import json
+    schema_obj = make_json_schema(schema_slug)
+    schema_str = json.dumps(schema_obj, indent=4, sort_keys=True)
+    return http.HttpResponse(schema_str, content_type='text/plain')
+
 def data_type_list(request, schema_slug):
     schema = get_object_or_404(XMLSchema, slug=schema_slug)
     return render(request, 'data_type_list.html', {

--- a/docs/concepts/index.html
+++ b/docs/concepts/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../mnx-reference/objects/">Objects</a></li>
     <li><a href="../mnx-reference/examples/">Example documents</a></li>
+    <li><a href="../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="mnx-reference/objects/">Objects</a></li>
     <li><a href="mnx-reference/examples/">Example documents</a></li>
+    <li><a href="mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/infrastructure/direction-content/index.html
+++ b/docs/infrastructure/direction-content/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../mnx-reference/objects/">Objects</a></li>
     <li><a href="../../mnx-reference/examples/">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/infrastructure/index.html
+++ b/docs/infrastructure/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../mnx-reference/objects/">Objects</a></li>
     <li><a href="../mnx-reference/examples/">Example documents</a></li>
+    <li><a href="../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/infrastructure/notational-concepts/index.html
+++ b/docs/infrastructure/notational-concepts/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../mnx-reference/objects/">Objects</a></li>
     <li><a href="../../mnx-reference/examples/">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/infrastructure/sequence-content/index.html
+++ b/docs/infrastructure/sequence-content/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../mnx-reference/objects/">Objects</a></li>
     <li><a href="../../mnx-reference/examples/">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/infrastructure/styling/index.html
+++ b/docs/infrastructure/styling/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../mnx-reference/objects/">Objects</a></li>
     <li><a href="../../mnx-reference/examples/">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/accidental/index.html
+++ b/docs/mnx-reference/data-types/accidental/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/barline/index.html
+++ b/docs/mnx-reference/data-types/barline/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/beam-hook-direction/index.html
+++ b/docs/mnx-reference/data-types/beam-hook-direction/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/chromatic-pitch/index.html
+++ b/docs/mnx-reference/data-types/chromatic-pitch/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/clef-sign/index.html
+++ b/docs/mnx-reference/data-types/clef-sign/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/css-selector/index.html
+++ b/docs/mnx-reference/data-types/css-selector/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/display-option/index.html
+++ b/docs/mnx-reference/data-types/display-option/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/dynamic-type/index.html
+++ b/docs/mnx-reference/data-types/dynamic-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/element-location/index.html
+++ b/docs/mnx-reference/data-types/element-location/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/ending-number/index.html
+++ b/docs/mnx-reference/data-types/ending-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/ending-type/index.html
+++ b/docs/mnx-reference/data-types/ending-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/event-id-list/index.html
+++ b/docs/mnx-reference/data-types/event-id-list/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/event-id/index.html
+++ b/docs/mnx-reference/data-types/event-id/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/floating-point-number/index.html
+++ b/docs/mnx-reference/data-types/floating-point-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/grace-note-type/index.html
+++ b/docs/mnx-reference/data-types/grace-note-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/grouping-symbol/index.html
+++ b/docs/mnx-reference/data-types/grouping-symbol/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/index.html
+++ b/docs/mnx-reference/data-types/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../objects/">Objects</a></li>
     <li><a href="../examples/">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/integer-signed/index.html
+++ b/docs/mnx-reference/data-types/integer-signed/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/jump-type/index.html
+++ b/docs/mnx-reference/data-types/jump-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/line-type/index.html
+++ b/docs/mnx-reference/data-types/line-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/measure-count/index.html
+++ b/docs/mnx-reference/data-types/measure-count/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/measure-location/index.html
+++ b/docs/mnx-reference/data-types/measure-location/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/measure-number/index.html
+++ b/docs/mnx-reference/data-types/measure-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/note-id/index.html
+++ b/docs/mnx-reference/data-types/note-id/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/note-value-quantity/index.html
+++ b/docs/mnx-reference/data-types/note-value-quantity/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/note-value/index.html
+++ b/docs/mnx-reference/data-types/note-value/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/octave-shift-type/index.html
+++ b/docs/mnx-reference/data-types/octave-shift-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/orientation/index.html
+++ b/docs/mnx-reference/data-types/orientation/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/part-id/index.html
+++ b/docs/mnx-reference/data-types/part-id/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/part-stem-direction/index.html
+++ b/docs/mnx-reference/data-types/part-stem-direction/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/perform-option/index.html
+++ b/docs/mnx-reference/data-types/perform-option/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/repeat-times/index.html
+++ b/docs/mnx-reference/data-types/repeat-times/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/repeat-type/index.html
+++ b/docs/mnx-reference/data-types/repeat-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/simple-color/index.html
+++ b/docs/mnx-reference/data-types/simple-color/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/slur-side/index.html
+++ b/docs/mnx-reference/data-types/slur-side/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/slur-tie-end-location/index.html
+++ b/docs/mnx-reference/data-types/slur-tie-end-location/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/smufl-font-name/index.html
+++ b/docs/mnx-reference/data-types/smufl-font-name/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/smufl-glyph-name/index.html
+++ b/docs/mnx-reference/data-types/smufl-glyph-name/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/staff-index/index.html
+++ b/docs/mnx-reference/data-types/staff-index/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/staff-label-type/index.html
+++ b/docs/mnx-reference/data-types/staff-label-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/staff-line/index.html
+++ b/docs/mnx-reference/data-types/staff-line/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/stave-count/index.html
+++ b/docs/mnx-reference/data-types/stave-count/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/stem-direction/index.html
+++ b/docs/mnx-reference/data-types/stem-direction/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/string/index.html
+++ b/docs/mnx-reference/data-types/string/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/style-class/index.html
+++ b/docs/mnx-reference/data-types/style-class/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/system-layout-id/index.html
+++ b/docs/mnx-reference/data-types/system-layout-id/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/time-signature/index.html
+++ b/docs/mnx-reference/data-types/time-signature/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/tuplet-display-setting/index.html
+++ b/docs/mnx-reference/data-types/tuplet-display-setting/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/visibility-option/index.html
+++ b/docs/mnx-reference/data-types/visibility-option/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/voice-id/index.html
+++ b/docs/mnx-reference/data-types/voice-id/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/voice-stem-direction/index.html
+++ b/docs/mnx-reference/data-types/voice-stem-direction/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/wedge-type/index.html
+++ b/docs/mnx-reference/data-types/wedge-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/yes-no-or-auto/index.html
+++ b/docs/mnx-reference/data-types/yes-no-or-auto/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/data-types/yes-or-no/index.html
+++ b/docs/mnx-reference/data-types/yes-or-no/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/accidentals/index.html
+++ b/docs/mnx-reference/examples/accidentals/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/beam-hooks/index.html
+++ b/docs/mnx-reference/examples/beam-hooks/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/beams-across-barlines/index.html
+++ b/docs/mnx-reference/examples/beams-across-barlines/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/beams-inner-grace-notes/index.html
+++ b/docs/mnx-reference/examples/beams-inner-grace-notes/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/beams-secondary-beam-breaks/index.html
+++ b/docs/mnx-reference/examples/beams-secondary-beam-breaks/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/beams/index.html
+++ b/docs/mnx-reference/examples/beams/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/clef-changes/index.html
+++ b/docs/mnx-reference/examples/clef-changes/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/dotted-notes/index.html
+++ b/docs/mnx-reference/examples/dotted-notes/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/grace-note/index.html
+++ b/docs/mnx-reference/examples/grace-note/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/grace-notes-beamed/index.html
+++ b/docs/mnx-reference/examples/grace-notes-beamed/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/hello-world/index.html
+++ b/docs/mnx-reference/examples/hello-world/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/index.html
+++ b/docs/mnx-reference/examples/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../objects/">Objects</a></li>
     <li><a href="./">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/jumps-dal-segno/index.html
+++ b/docs/mnx-reference/examples/jumps-dal-segno/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/jumps-ds-al-fine/index.html
+++ b/docs/mnx-reference/examples/jumps-ds-al-fine/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/key-signatures/index.html
+++ b/docs/mnx-reference/examples/key-signatures/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/multimeasure-rests/index.html
+++ b/docs/mnx-reference/examples/multimeasure-rests/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/multiple-layouts/index.html
+++ b/docs/mnx-reference/examples/multiple-layouts/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/multiple-voices/index.html
+++ b/docs/mnx-reference/examples/multiple-voices/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/octave-shifts-8va/index.html
+++ b/docs/mnx-reference/examples/octave-shifts-8va/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/orchestral-layout/index.html
+++ b/docs/mnx-reference/examples/orchestral-layout/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/organ-layout/index.html
+++ b/docs/mnx-reference/examples/organ-layout/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/parts/index.html
+++ b/docs/mnx-reference/examples/parts/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/repeats-alternate-endings-advanced/index.html
+++ b/docs/mnx-reference/examples/repeats-alternate-endings-advanced/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/repeats-alternate-endings-simple/index.html
+++ b/docs/mnx-reference/examples/repeats-alternate-endings-simple/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/repeats-implied-start-repeat/index.html
+++ b/docs/mnx-reference/examples/repeats-implied-start-repeat/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/repeats-more-once-repeated/index.html
+++ b/docs/mnx-reference/examples/repeats-more-once-repeated/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/repeats/index.html
+++ b/docs/mnx-reference/examples/repeats/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/rest-positions/index.html
+++ b/docs/mnx-reference/examples/rest-positions/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/slurs-chords/index.html
+++ b/docs/mnx-reference/examples/slurs-chords/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/slurs-incomplete-slurs/index.html
+++ b/docs/mnx-reference/examples/slurs-incomplete-slurs/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/slurs-targeting-specific-notes/index.html
+++ b/docs/mnx-reference/examples/slurs-targeting-specific-notes/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/slurs/index.html
+++ b/docs/mnx-reference/examples/slurs/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/style-class-basic/index.html
+++ b/docs/mnx-reference/examples/style-class-basic/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/style-element-basic/index.html
+++ b/docs/mnx-reference/examples/style-element-basic/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/system-layouts/index.html
+++ b/docs/mnx-reference/examples/system-layouts/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/tempo-markings/index.html
+++ b/docs/mnx-reference/examples/tempo-markings/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/three-note-chord-and-half-rest/index.html
+++ b/docs/mnx-reference/examples/three-note-chord-and-half-rest/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/ties/index.html
+++ b/docs/mnx-reference/examples/ties/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/time-signatures/index.html
+++ b/docs/mnx-reference/examples/time-signatures/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/tuplets/index.html
+++ b/docs/mnx-reference/examples/tuplets/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/examples/two-bar-c-major-scale/index.html
+++ b/docs/mnx-reference/examples/two-bar-c-major-scale/index.html
@@ -36,6 +36,7 @@
     <ul>
     <li><a href="../../objects/">Objects</a></li>
     <li><a href="../">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/index.html
+++ b/docs/mnx-reference/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="objects/">Objects</a></li>
     <li><a href="examples/">Example documents</a></li>
+    <li><a href="../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/accidental-display/index.html
+++ b/docs/mnx-reference/objects/accidental-display/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/alter/index.html
+++ b/docs/mnx-reference/objects/alter/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/barline-type/index.html
+++ b/docs/mnx-reference/objects/barline-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/barline/index.html
+++ b/docs/mnx-reference/objects/barline/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/beam-hook-direction/index.html
+++ b/docs/mnx-reference/objects/beam-hook-direction/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/beam-hook/index.html
+++ b/docs/mnx-reference/objects/beam-hook/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/beam/index.html
+++ b/docs/mnx-reference/objects/beam/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/boolean/index.html
+++ b/docs/mnx-reference/objects/boolean/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/bpm/index.html
+++ b/docs/mnx-reference/objects/bpm/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/clef-sign/index.html
+++ b/docs/mnx-reference/objects/clef-sign/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/clef/index.html
+++ b/docs/mnx-reference/objects/clef/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/color/index.html
+++ b/docs/mnx-reference/objects/color/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/dynamic-type/index.html
+++ b/docs/mnx-reference/objects/dynamic-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/dynamic/index.html
+++ b/docs/mnx-reference/objects/dynamic/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/ending-duration/index.html
+++ b/docs/mnx-reference/objects/ending-duration/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/ending-number/index.html
+++ b/docs/mnx-reference/objects/ending-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/ending-open/index.html
+++ b/docs/mnx-reference/objects/ending-open/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/ending/index.html
+++ b/docs/mnx-reference/objects/ending/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/event/index.html
+++ b/docs/mnx-reference/objects/event/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/fifths/index.html
+++ b/docs/mnx-reference/objects/fifths/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/fine/index.html
+++ b/docs/mnx-reference/objects/fine/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/global/index.html
+++ b/docs/mnx-reference/objects/global/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/grace-type/index.html
+++ b/docs/mnx-reference/objects/grace-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/grace/index.html
+++ b/docs/mnx-reference/objects/grace/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/id/index.html
+++ b/docs/mnx-reference/objects/id/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/index.html
+++ b/docs/mnx-reference/objects/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="./">Objects</a></li>
     <li><a href="../examples/">Example documents</a></li>
+    <li><a href="../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/integer-signed/index.html
+++ b/docs/mnx-reference/objects/integer-signed/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/integer-unsigned/index.html
+++ b/docs/mnx-reference/objects/integer-unsigned/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/jump-type/index.html
+++ b/docs/mnx-reference/objects/jump-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/jump/index.html
+++ b/docs/mnx-reference/objects/jump/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/key/index.html
+++ b/docs/mnx-reference/objects/key/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/layout-change/index.html
+++ b/docs/mnx-reference/objects/layout-change/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/line-type/index.html
+++ b/docs/mnx-reference/objects/line-type/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/measure-count/index.html
+++ b/docs/mnx-reference/objects/measure-count/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/measure-global/index.html
+++ b/docs/mnx-reference/objects/measure-global/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/measure-location/index.html
+++ b/docs/mnx-reference/objects/measure-location/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/measure-number/index.html
+++ b/docs/mnx-reference/objects/measure-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/mnx/index.html
+++ b/docs/mnx-reference/objects/mnx/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/multimeasure-rest/index.html
+++ b/docs/mnx-reference/objects/multimeasure-rest/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/note-value-base/index.html
+++ b/docs/mnx-reference/objects/note-value-base/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/note-value-quantity/index.html
+++ b/docs/mnx-reference/objects/note-value-quantity/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/note-value/index.html
+++ b/docs/mnx-reference/objects/note-value/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/note/index.html
+++ b/docs/mnx-reference/objects/note/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/octave-shift-amount/index.html
+++ b/docs/mnx-reference/objects/octave-shift-amount/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/octave-shift/index.html
+++ b/docs/mnx-reference/objects/octave-shift/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/octave/index.html
+++ b/docs/mnx-reference/objects/octave/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/orientation/index.html
+++ b/docs/mnx-reference/objects/orientation/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/page/index.html
+++ b/docs/mnx-reference/objects/page/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/part-measure/index.html
+++ b/docs/mnx-reference/objects/part-measure/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/part-name/index.html
+++ b/docs/mnx-reference/objects/part-name/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/part-short-name/index.html
+++ b/docs/mnx-reference/objects/part-short-name/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/part/index.html
+++ b/docs/mnx-reference/objects/part/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/perform-options/index.html
+++ b/docs/mnx-reference/objects/perform-options/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/pitch/index.html
+++ b/docs/mnx-reference/objects/pitch/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/positioned-clef/index.html
+++ b/docs/mnx-reference/objects/positioned-clef/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/positive-integer/index.html
+++ b/docs/mnx-reference/objects/positive-integer/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/repeat-end/index.html
+++ b/docs/mnx-reference/objects/repeat-end/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/repeat-start/index.html
+++ b/docs/mnx-reference/objects/repeat-start/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/repeat-times/index.html
+++ b/docs/mnx-reference/objects/repeat-times/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/rest/index.html
+++ b/docs/mnx-reference/objects/rest/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/rhythmic-position/index.html
+++ b/docs/mnx-reference/objects/rhythmic-position/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/root/index.html
+++ b/docs/mnx-reference/objects/root/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/score-name/index.html
+++ b/docs/mnx-reference/objects/score-name/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/score/index.html
+++ b/docs/mnx-reference/objects/score/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/segno/index.html
+++ b/docs/mnx-reference/objects/segno/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/sequence/index.html
+++ b/docs/mnx-reference/objects/sequence/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/simple-color/index.html
+++ b/docs/mnx-reference/objects/simple-color/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/slur-side/index.html
+++ b/docs/mnx-reference/objects/slur-side/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/slur-tie-end-location/index.html
+++ b/docs/mnx-reference/objects/slur-tie-end-location/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/slur/index.html
+++ b/docs/mnx-reference/objects/slur/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/smufl-font/index.html
+++ b/docs/mnx-reference/objects/smufl-font/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/smufl-glyph/index.html
+++ b/docs/mnx-reference/objects/smufl-glyph/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/space/index.html
+++ b/docs/mnx-reference/objects/space/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/staff-number/index.html
+++ b/docs/mnx-reference/objects/staff-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/staff-position/index.html
+++ b/docs/mnx-reference/objects/staff-position/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave-count/index.html
+++ b/docs/mnx-reference/objects/stave-count/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave-group/index.html
+++ b/docs/mnx-reference/objects/stave-group/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave-label/index.html
+++ b/docs/mnx-reference/objects/stave-label/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave-labelref/index.html
+++ b/docs/mnx-reference/objects/stave-labelref/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave-source/index.html
+++ b/docs/mnx-reference/objects/stave-source/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave-symbol/index.html
+++ b/docs/mnx-reference/objects/stave-symbol/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stave/index.html
+++ b/docs/mnx-reference/objects/stave/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/stem-direction/index.html
+++ b/docs/mnx-reference/objects/stem-direction/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/step/index.html
+++ b/docs/mnx-reference/objects/step/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/string/index.html
+++ b/docs/mnx-reference/objects/string/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/style-class/index.html
+++ b/docs/mnx-reference/objects/style-class/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/style-global/index.html
+++ b/docs/mnx-reference/objects/style-global/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/style-selector/index.html
+++ b/docs/mnx-reference/objects/style-selector/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/system-layout/index.html
+++ b/docs/mnx-reference/objects/system-layout/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/system/index.html
+++ b/docs/mnx-reference/objects/system/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/tempo/index.html
+++ b/docs/mnx-reference/objects/tempo/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/tied/index.html
+++ b/docs/mnx-reference/objects/tied/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/time-signature-unit/index.html
+++ b/docs/mnx-reference/objects/time-signature-unit/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/time/index.html
+++ b/docs/mnx-reference/objects/time/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/tuplet-display-setting/index.html
+++ b/docs/mnx-reference/objects/tuplet-display-setting/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/tuplet/index.html
+++ b/docs/mnx-reference/objects/tuplet/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/version-number/index.html
+++ b/docs/mnx-reference/objects/version-number/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/voice-name/index.html
+++ b/docs/mnx-reference/objects/voice-name/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-reference/objects/yes-no-auto/index.html
+++ b/docs/mnx-reference/objects/yes-no-auto/index.html
@@ -32,6 +32,7 @@
     <ul>
     <li><a href="../">Objects</a></li>
     <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
     </ul>
 </li>
 <li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>

--- a/docs/mnx-schema.json
+++ b/docs/mnx-schema.json
@@ -1,0 +1,975 @@
+{
+    "$defs": {
+        "beam-list": {
+            "items": {
+                "additionalProperties": false,
+                "properties": {
+                    "events": {
+                        "items": {
+                            "$ref": "#/$defs/id"
+                        },
+                        "type": "array"
+                    },
+                    "hooks": {
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "direction": {
+                                    "type": "string"
+                                },
+                                "event": {
+                                    "$ref": "#/$defs/id"
+                                }
+                            },
+                            "required": [
+                                "direction",
+                                "event"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "inner": {
+                        "$ref": "#/$defs/beam-list"
+                    }
+                },
+                "required": [
+                    "events"
+                ],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "color": {
+            "type": "string"
+        },
+        "event": {
+            "additionalProperties": false,
+            "properties": {
+                "duration": {
+                    "$ref": "#/$defs/note-value"
+                },
+                "id": {
+                    "$ref": "#/$defs/id"
+                },
+                "measure": {
+                    "type": "boolean"
+                },
+                "notes": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "accidentalDisplay": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "cautionary": {
+                                        "type": "boolean"
+                                    },
+                                    "editorial": {
+                                        "type": "boolean"
+                                    },
+                                    "show": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "show"
+                                ],
+                                "type": "object"
+                            },
+                            "class": {
+                                "$ref": "#/$defs/style-class"
+                            },
+                            "id": {
+                                "$ref": "#/$defs/id"
+                            },
+                            "perform": {
+                                "additionalProperties": false,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "pitch": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "alter": {
+                                        "type": "integer"
+                                    },
+                                    "octave": {
+                                        "type": "integer"
+                                    },
+                                    "step": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "octave",
+                                    "step"
+                                ],
+                                "type": "object"
+                            },
+                            "smufl-font": {
+                                "$ref": "#/$defs/smufl-font"
+                            },
+                            "staff": {
+                                "$ref": "#/$defs/staff-number"
+                            },
+                            "tied": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "location": {
+                                        "$ref": "#/$defs/slur-tie-end-location"
+                                    },
+                                    "target": {
+                                        "$ref": "#/$defs/id"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "pitch"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "orient": {
+                    "$ref": "#/$defs/orientation"
+                },
+                "rest": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "position": {
+                            "$ref": "#/$defs/staff-position"
+                        }
+                    },
+                    "type": "object"
+                },
+                "slurs": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "end-note": {
+                                "$ref": "#/$defs/id"
+                            },
+                            "line-type": {
+                                "type": "string"
+                            },
+                            "location": {
+                                "$ref": "#/$defs/slur-tie-end-location"
+                            },
+                            "side": {
+                                "$ref": "#/$defs/slur-side"
+                            },
+                            "side-end": {
+                                "$ref": "#/$defs/slur-side"
+                            },
+                            "start-note": {
+                                "$ref": "#/$defs/id"
+                            },
+                            "target": {
+                                "$ref": "#/$defs/id"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "smufl-font": {
+                    "$ref": "#/$defs/smufl-font"
+                },
+                "staff": {
+                    "$ref": "#/$defs/staff-number"
+                },
+                "stem-direction": {
+                    "$ref": "#/$defs/stem-direction"
+                },
+                "type": {
+                    "const": "event",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "id": {
+            "type": "string"
+        },
+        "integer-unsigned": {
+            "type": "integer"
+        },
+        "measure-location": {
+            "type": "string"
+        },
+        "measure-number": {
+            "type": "integer"
+        },
+        "note-value": {
+            "additionalProperties": false,
+            "properties": {
+                "base": {
+                    "type": "string"
+                },
+                "dots": {
+                    "$ref": "#/$defs/positive-integer"
+                }
+            },
+            "required": [
+                "base"
+            ],
+            "type": "object"
+        },
+        "note-value-quantity": {
+            "additionalProperties": false,
+            "properties": {
+                "duration": {
+                    "$ref": "#/$defs/note-value"
+                },
+                "multiple": {
+                    "$ref": "#/$defs/positive-integer"
+                }
+            },
+            "required": [
+                "duration",
+                "multiple"
+            ],
+            "type": "object"
+        },
+        "orientation": {
+            "type": "string"
+        },
+        "positive-integer": {
+            "type": "integer"
+        },
+        "slur-side": {
+            "type": "string"
+        },
+        "slur-tie-end-location": {
+            "type": "string"
+        },
+        "smufl-font": {
+            "type": "string"
+        },
+        "smufl-glyph": {
+            "type": "string"
+        },
+        "staff-number": {
+            "type": "integer"
+        },
+        "staff-position": {
+            "type": "integer"
+        },
+        "stave-label": {
+            "type": "string"
+        },
+        "stave-labelref": {
+            "type": "string"
+        },
+        "stave-symbol": {
+            "type": "string"
+        },
+        "stem-direction": {
+            "type": "string"
+        },
+        "style-class": {
+            "type": "string"
+        },
+        "system-layout-content": {
+            "items": {
+                "anyOf": [
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "content": {
+                                "$ref": "#/$defs/system-layout-content"
+                            },
+                            "label": {
+                                "$ref": "#/$defs/stave-label"
+                            },
+                            "symbol": {
+                                "$ref": "#/$defs/stave-symbol"
+                            },
+                            "type": {
+                                "const": "group",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "additionalProperties": false,
+                        "properties": {
+                            "label": {
+                                "$ref": "#/$defs/stave-label"
+                            },
+                            "labelref": {
+                                "$ref": "#/$defs/stave-labelref"
+                            },
+                            "sources": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "label": {
+                                            "$ref": "#/$defs/stave-label"
+                                        },
+                                        "labelref": {
+                                            "$ref": "#/$defs/stave-labelref"
+                                        },
+                                        "part": {
+                                            "$ref": "#/$defs/id"
+                                        },
+                                        "staff": {
+                                            "$ref": "#/$defs/staff-number"
+                                        },
+                                        "stem": {
+                                            "$ref": "#/$defs/stem-direction"
+                                        },
+                                        "voice": {
+                                            "$ref": "#/$defs/voice-name"
+                                        }
+                                    },
+                                    "required": [
+                                        "part"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "symbol": {
+                                "$ref": "#/$defs/stave-symbol"
+                            },
+                            "type": {
+                                "const": "staff",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "sources",
+                            "type"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "tuplet-display-setting": {
+            "type": "string"
+        },
+        "voice-name": {
+            "type": "string"
+        }
+    },
+    "$id": "https://w3c.github.io/mnx/docs/mnx-schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "description": "An encoding of Common Western Music Notation.",
+    "properties": {
+        "global": {
+            "additionalProperties": false,
+            "properties": {
+                "measures": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "barline": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "ending": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "class": {
+                                        "$ref": "#/$defs/style-class"
+                                    },
+                                    "color": {
+                                        "$ref": "#/$defs/color"
+                                    },
+                                    "duration": {
+                                        "type": "integer"
+                                    },
+                                    "numbers": {
+                                        "items": {
+                                            "type": "integer"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "open": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "duration"
+                                ],
+                                "type": "object"
+                            },
+                            "fine": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "class": {
+                                        "$ref": "#/$defs/style-class"
+                                    },
+                                    "color": {
+                                        "$ref": "#/$defs/color"
+                                    },
+                                    "location": {
+                                        "$ref": "#/$defs/measure-location"
+                                    }
+                                },
+                                "required": [
+                                    "location"
+                                ],
+                                "type": "object"
+                            },
+                            "index": {
+                                "$ref": "#/$defs/measure-number"
+                            },
+                            "jump": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "location": {
+                                        "$ref": "#/$defs/measure-location"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "location",
+                                    "type"
+                                ],
+                                "type": "object"
+                            },
+                            "key": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "class": {
+                                        "$ref": "#/$defs/style-class"
+                                    },
+                                    "color": {
+                                        "$ref": "#/$defs/color"
+                                    },
+                                    "fifths": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "fifths"
+                                ],
+                                "type": "object"
+                            },
+                            "number": {
+                                "$ref": "#/$defs/measure-number"
+                            },
+                            "repeat-end": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "times": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "repeat-start": {
+                                "additionalProperties": false,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "segno": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "class": {
+                                        "$ref": "#/$defs/style-class"
+                                    },
+                                    "color": {
+                                        "$ref": "#/$defs/color"
+                                    },
+                                    "glyph": {
+                                        "$ref": "#/$defs/smufl-glyph"
+                                    },
+                                    "location": {
+                                        "$ref": "#/$defs/measure-location"
+                                    }
+                                },
+                                "required": [
+                                    "location"
+                                ],
+                                "type": "object"
+                            },
+                            "tempos": {
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "bpm": {
+                                            "type": "integer"
+                                        },
+                                        "location": {
+                                            "$ref": "#/$defs/measure-location"
+                                        },
+                                        "value": {
+                                            "$ref": "#/$defs/note-value"
+                                        }
+                                    },
+                                    "required": [
+                                        "bpm",
+                                        "value"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "time": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "count": {
+                                        "$ref": "#/$defs/positive-integer"
+                                    },
+                                    "unit": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "count",
+                                    "unit"
+                                ],
+                                "type": "object"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "styles": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "color": {
+                                "$ref": "#/$defs/color"
+                            },
+                            "selector": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "selector"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "measures"
+            ],
+            "type": "object"
+        },
+        "layouts": {
+            "items": {
+                "additionalProperties": false,
+                "properties": {
+                    "content": {
+                        "$ref": "#/$defs/system-layout-content"
+                    },
+                    "id": {
+                        "$ref": "#/$defs/id"
+                    }
+                },
+                "required": [
+                    "content",
+                    "id"
+                ],
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "mnx": {
+            "additionalProperties": false,
+            "properties": {
+                "version": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "version"
+            ],
+            "type": "object"
+        },
+        "parts": {
+            "items": {
+                "additionalProperties": false,
+                "properties": {
+                    "id": {
+                        "$ref": "#/$defs/id"
+                    },
+                    "measures": {
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "beams": {
+                                    "$ref": "#/$defs/beam-list"
+                                },
+                                "clefs": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "clef": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "class": {
+                                                        "$ref": "#/$defs/style-class"
+                                                    },
+                                                    "color": {
+                                                        "type": "string"
+                                                    },
+                                                    "glyph": {
+                                                        "$ref": "#/$defs/smufl-glyph"
+                                                    },
+                                                    "octave": {
+                                                        "type": "integer"
+                                                    },
+                                                    "position": {
+                                                        "$ref": "#/$defs/staff-position"
+                                                    },
+                                                    "sign": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "position",
+                                                    "sign"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "position": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "fraction": {
+                                                        "items": {
+                                                            "$ref": "#/$defs/integer-unsigned"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "graceIndex": {
+                                                        "$ref": "#/$defs/integer-unsigned"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "fraction"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        },
+                                        "required": [
+                                            "clef"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "sequences": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "content": {
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/event"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "class": {
+                                                                    "$ref": "#/$defs/style-class"
+                                                                },
+                                                                "color": {
+                                                                    "$ref": "#/$defs/color"
+                                                                },
+                                                                "content": {
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/event"
+                                                                    },
+                                                                    "type": "array"
+                                                                },
+                                                                "grace-type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "slash": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "type": {
+                                                                    "const": "grace",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "content",
+                                                                "type"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "bracket": {
+                                                                    "type": "string"
+                                                                },
+                                                                "content": {
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/event"
+                                                                    },
+                                                                    "type": "array"
+                                                                },
+                                                                "inner": {
+                                                                    "$ref": "#/$defs/note-value-quantity"
+                                                                },
+                                                                "orient": {
+                                                                    "$ref": "#/$defs/orientation"
+                                                                },
+                                                                "outer": {
+                                                                    "$ref": "#/$defs/note-value-quantity"
+                                                                },
+                                                                "show-number": {
+                                                                    "$ref": "#/$defs/tuplet-display-setting"
+                                                                },
+                                                                "show-value": {
+                                                                    "$ref": "#/$defs/tuplet-display-setting"
+                                                                },
+                                                                "staff": {
+                                                                    "$ref": "#/$defs/staff-number"
+                                                                },
+                                                                "type": {
+                                                                    "const": "tuplet",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "content",
+                                                                "inner",
+                                                                "outer",
+                                                                "type"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "end": {
+                                                                    "$ref": "#/$defs/measure-location"
+                                                                },
+                                                                "orient": {
+                                                                    "$ref": "#/$defs/orientation"
+                                                                },
+                                                                "staff": {
+                                                                    "$ref": "#/$defs/staff-number"
+                                                                },
+                                                                "type": {
+                                                                    "const": "octave-shift",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "type": "integer"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "end",
+                                                                "type",
+                                                                "value"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "duration": {
+                                                                    "$ref": "#/$defs/note-value-quantity"
+                                                                },
+                                                                "type": {
+                                                                    "const": "space",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "duration",
+                                                                "type"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "glyph": {
+                                                                    "$ref": "#/$defs/smufl-glyph"
+                                                                },
+                                                                "type": {
+                                                                    "const": "dynamic",
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "value"
+                                                            ],
+                                                            "type": "object"
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "array"
+                                            },
+                                            "orient": {
+                                                "$ref": "#/$defs/orientation"
+                                            },
+                                            "staff": {
+                                                "$ref": "#/$defs/staff-number"
+                                            },
+                                            "voice": {
+                                                "$ref": "#/$defs/voice-name"
+                                            }
+                                        },
+                                        "required": [
+                                            "content"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "sequences"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "short-name": {
+                        "type": "string"
+                    },
+                    "smufl-font": {
+                        "$ref": "#/$defs/smufl-font"
+                    },
+                    "staves": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "scores": {
+            "items": {
+                "additionalProperties": false,
+                "properties": {
+                    "layout": {
+                        "$ref": "#/$defs/id"
+                    },
+                    "multimeasure-rests": {
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "duration": {
+                                    "type": "integer"
+                                },
+                                "label": {
+                                    "type": "string"
+                                },
+                                "start": {
+                                    "$ref": "#/$defs/measure-number"
+                                }
+                            },
+                            "required": [
+                                "duration",
+                                "start"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "pages": {
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "layout": {
+                                    "$ref": "#/$defs/id"
+                                },
+                                "systems": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "layout": {
+                                                "$ref": "#/$defs/id"
+                                            },
+                                            "layout-changes": {
+                                                "items": {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                        "layout": {
+                                                            "$ref": "#/$defs/id"
+                                                        },
+                                                        "location": {
+                                                            "$ref": "#/$defs/measure-location"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "layout",
+                                                        "location"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "measure": {
+                                                "$ref": "#/$defs/measure-number"
+                                            }
+                                        },
+                                        "required": [
+                                            "measure"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "systems"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "type": "object"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "global",
+        "mnx",
+        "parts"
+    ],
+    "title": "MNX document",
+    "type": "object"
+}


### PR DESCRIPTION
In this pull request, I've improved our docs system to automatically create a JSON Schema from the data in the docs system.

This means, whenever we add or change things in MNX, we'll get an automatically updated, machine-readable JSON Schema "for free."

You can view the generated JSON Schema here, as it stands on this branch:

https://cdn.githubraw.com/w3c/mnx/json-schema/docs/mnx-schema.json

It's linked-to from the left sidebar of each docs page ("Raw JSON Schema"):

<img width="194" alt="Screenshot 2023-12-07 at 3 58 27 PM" src="https://github.com/w3c/mnx/assets/180401/a589c381-59f9-4940-8184-f39a90aaeb3e">

An implementation note: this automatically creates `$def`s for any object that's referenced more than once. Otherwise, it puts the various definitions inline/nested. I figured this approach would result in the best readability, but the logic is easy to tweak if needed.

I tested it against one of our example MNX documents, using an online JSON Schema validator, and it validated with no errors. I still need to test against all the other MNX examples.

I'd like to thank @paul-bayleaf and his work on #308 for laying the groundwork for this! I used his manually created JSON Schema document as a reference, and this project would have taken significantly longer to implement without that.

If anybody has feedback on this JSON Schema, please leave a comment!