### PR TITLE
Ignore common dev folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ deploy_key
 .DS_Store
 docgenerator/db.sqlite3
 __pycache__
+venv/
+.idea/


### PR DESCRIPTION
These can be set up by individuals to ignore, but they're common enough that I think it's worth putting into the repo.