### PR TITLE
Added 'support' key with 'useAccidentalDisplay'

### DIFF
--- a/docgenerator/data.json
+++ b/docgenerator/data.json
@@ -1799,6 +1799,17 @@
     }
 },
 {
+    "model": "spec.jsonobject",
+    "pk": 162,
+    "fields": {
+        "name": "support",
+        "slug": "support",
+        "schema": 1,
+        "object_type": 1,
+        "description": "<p>This contains information about how to interpret the data within an MNX document.</p>"
+    }
+},
+{
     "model": "spec.jsonobjectrelationship",
     "pk": 1,
     "fields": {
@@ -4042,7 +4053,13 @@
         "child_key": "accidentalDisplay",
         "child": 135,
         "is_required": false,
-        "description": "Information about the displayed accidental for this note. This is required for any note that has a displayed accidental."
+        "description": [
+            "Information about the displayed accidental for this note.",
+            "",
+            "If this MNX document has \"useAccidentalDisplay\" set to true in its top-level \"mnx\" object's \"supports\" object, this \"accidentalDisplay\" key is required for any note that has a displayed accidental.",
+            "",
+            "If \"useAccidentalDisplay\" is missing or set to false, notes must not include \"accidentalDisplay\"."
+        ]
     }
 },
 {
@@ -4390,6 +4407,36 @@
         "child": 105,
         "is_required": false,
         "description": "In a multi-staff part, this specifies which staff the clef is in. If unspecified, this should be interpreted as 1."
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 245,
+    "fields": {
+        "parent": 126,
+        "child_key": "support",
+        "child": 162,
+        "is_required": false,
+        "description": "Information about how to interpret the data in this MNX file, in cases of ambiguity."
+    }
+},
+{
+    "model": "spec.jsonobjectrelationship",
+    "pk": 246,
+    "fields": {
+        "parent": 162,
+        "child_key": "useAccidentalDisplay",
+        "child": 112,
+        "is_required": false,
+        "description": [
+            "This answers the question \"Does every note with a visible accidental have accidentalDisplay set?\"",
+            "",
+            "If this is set to true, then consuming applications should only draw an accidental on notes that have an \"accidentalDisplay\" value.",
+            "",
+            "If this is set to false, then consuming applications should use their own algorithm to determine whether any given note's accidental should be drawn.",
+            "",
+            "If this value is not provided, it is to be interpreted as false."
+        ]
     }
 },
 {
@@ -5517,7 +5564,7 @@
         "blurb": "",
         "document": [
             "{",
-            "  \"mnx\": {\"version\": 1},",
+            "  \"mnx\": {\"version\": 1, \"support\": {\"useAccidentalDisplay\": true}},",
             "  \"global\": {",
             "    \"measures\": [",
             "      {",
@@ -9404,7 +9451,7 @@
         "blurb": "Note only the music in the first measure is encoded here.",
         "document": [
             "{",
-            "\"mnx\": {\"version\": 1},",
+            "  \"mnx\": {\"version\": 1, \"support\": {\"useAccidentalDisplay\": true}},",
             "  \"global\": {",
             "    \"measures\": [",
             "      {",
@@ -23818,6 +23865,22 @@
     "fields": {
         "example": 44,
         "json_object": 39
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1414,
+    "fields": {
+        "example": 6,
+        "json_object": 162
+    }
+},
+{
+    "model": "spec.exampledocumentobject",
+    "pk": 1415,
+    "fields": {
+        "example": 35,
+        "json_object": 162
     }
 },
 {

--- a/docs/comparisons/musicxml/index.html
+++ b/docs/comparisons/musicxml/index.html
@@ -1335,8 +1335,10 @@
         <h2>Accidentals</h2>
         <img class="exampleimg" src="../../static/examples/accidentals.png">
         
-        <p class="examplenotes">In MusicXML, use <code>&lt;accidental&gt;</code> within a <code>&lt;note&gt;</code> to indicate a rendered accidental. In MNX, give the note an <code>"accidentalDisplay"</code> key.</p>
-<p class="examplenotes">In both MusicXML and MNX, accidentals are only encoded if they are to be rendered. Notes whose accidental is implied from the key signature (such as the Bb note in bar 2 of this example), or notes repeating a currently active accidental (such as the second Db in bar 2), are not encoded as having an accidental.</p>
+        <p class="examplenotes">In MusicXML, use <code>&lt;accidental&gt;</code> within a <code>&lt;note&gt;</code> to indicate a rendered accidental. In MNX, give the note an <code>"accidentalDisplay"</code> key.</p>
+<p class="examplenotes"></p>
+<p class="examplenotes">In both MusicXML and MNX, accidentals are only encoded if they are to be rendered. Notes whose accidental is implied from the key signature (such as the Bb note in bar 2 of this example), or notes repeating a currently active accidental (such as the second Db in bar 2), are not encoded as having an accidental.</p>
+<p class="examplenotes"></p>
 <p class="examplenotes">Cautionary accidentals, such as the D natural in bar 3 of this example — that is, accidentals that are not technically required to be displayed and serve as a courtesy to the musician — are not treated any differently than “non-cautionary” accidentals.</p>
         
         
@@ -1453,6 +1455,9 @@
             <div class="markupcode">
                 <div class="xmlmarkup">{
    <a class="tag" href="../../mnx-reference/objects/root/">"mnx"</a>: {
+      <a class="tag" href="../../mnx-reference/objects/mnx/">"support"</a>: {
+         <a class="tag" href="../../mnx-reference/objects/support/">"useAccidentalDisplay"</a>: <a class="tag" href="../../mnx-reference/objects/boolean/">true</a>
+      },
       <a class="tag" href="../../mnx-reference/objects/mnx/">"version"</a>: <a class="tag" href="../../mnx-reference/objects/version-number/">1</a>
    },
    <a class="tag" href="../../mnx-reference/objects/root/">"global"</a>: {

--- a/docs/mnx-reference/examples/accidentals/index.html
+++ b/docs/mnx-reference/examples/accidentals/index.html
@@ -67,6 +67,9 @@
 
 <div class="xmlmarkup">{
    <a class="tag" href="../../objects/root/">"mnx"</a>: {
+      <a class="tag" href="../../objects/mnx/">"support"</a>: {
+         <a class="tag" href="../../objects/support/">"useAccidentalDisplay"</a>: <a class="tag" href="../../objects/boolean/">true</a>
+      },
       <a class="tag" href="../../objects/mnx/">"version"</a>: <a class="tag" href="../../objects/version-number/">1</a>
    },
    <a class="tag" href="../../objects/root/">"global"</a>: {

--- a/docs/mnx-reference/examples/organ-layout/index.html
+++ b/docs/mnx-reference/examples/organ-layout/index.html
@@ -67,6 +67,9 @@
 
 <div class="xmlmarkup">{
    <a class="tag" href="../../objects/root/">"mnx"</a>: {
+      <a class="tag" href="../../objects/mnx/">"support"</a>: {
+         <a class="tag" href="../../objects/support/">"useAccidentalDisplay"</a>: <a class="tag" href="../../objects/boolean/">true</a>
+      },
       <a class="tag" href="../../objects/mnx/">"version"</a>: <a class="tag" href="../../objects/version-number/">1</a>
    },
    <a class="tag" href="../../objects/root/">"global"</a>: {

--- a/docs/mnx-reference/objects/index.html
+++ b/docs/mnx-reference/objects/index.html
@@ -252,6 +252,8 @@
 
 <li><a href="style-selector/">style-selector</a></li>
 
+<li><a href="support/">support</a></li>
+
 <li><a href="system/">system</a></li>
 
 <li><a href="system-layout/">system layout</a></li>

--- a/docs/mnx-reference/objects/mnx/index.html
+++ b/docs/mnx-reference/objects/mnx/index.html
@@ -70,6 +70,17 @@
 
 
 <tr>
+    <td><nobr><b>"support"</b></nobr></td>
+    <td>
+        
+        <a href="../support/">support object</a>
+        
+    </td>
+    <td>No</td>
+    <td>Information about how to interpret the data in this MNX file, in cases of ambiguity.</td>
+</tr>
+
+<tr>
     <td><nobr><b>"version"</b></nobr></td>
     <td>
         

--- a/docs/mnx-reference/objects/note/index.html
+++ b/docs/mnx-reference/objects/note/index.html
@@ -77,7 +77,7 @@
         
     </td>
     <td>No</td>
-    <td>Information about the displayed accidental for this note. This is required for any note that has a displayed accidental.</td>
+    <td>Information about the displayed accidental for this note.<br><br>If this MNX document has "useAccidentalDisplay" set to true in its top-level "mnx" object's "supports" object, this "accidentalDisplay" key is required for any note that has a displayed accidental.<br><br>If "useAccidentalDisplay" is missing or set to false, notes must not include "accidentalDisplay".</td>
 </tr>
 
 <tr>

--- a/docs/mnx-reference/objects/support/index.html
+++ b/docs/mnx-reference/objects/support/index.html
@@ -1,0 +1,106 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>The support object | MNX specification</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="width=device-width">
+<link rel="stylesheet" href="../../../static/styles.css">
+
+</head>
+
+<body class="has-sidenav">
+<div class="topnav">
+    <button id="toggle" class="toggle">
+        <svg viewBox="0 0 100 80" width="16" height="16" fill="currentColor">
+          <rect width="100" height="20" rx="8"></rect>
+          <rect y="30" width="100" height="20" rx="8"></rect>
+          <rect y="60" width="100" height="20" rx="8"></rect>
+        </svg>
+    </button>
+    <a class="logo" href="../../../">
+        <span class="logo-text">MNX specification</span>
+    </a>
+</div>
+
+
+<div class="content">
+    <nav class="sidenav">
+        <ul>
+<li><a href="../../../">Home</a></li>
+<li><a href="../">Reference</a>
+    <ul>
+    <li><a href="../">Objects</a></li>
+    <li><a href="../../examples/">Example documents</a></li>
+    <li><a href="../../../mnx-schema.json">Raw JSON Schema</a></li>
+    </ul>
+</li>
+<li><a href="../../../comparisons/musicxml/">MNX and MusicXML</a></li>
+</ul>
+    </nav>
+    <main>
+    
+<p class="breadcrumb">
+    <a href="../../../">MNX specification</a> &gt;
+    <a href="../../">MNX reference</a> &gt;
+    <a href="../">Objects</a> &gt;
+    support
+</p>
+
+<h1>The support object</h1>
+
+<p><b>Type:</b> Dictionary</p>
+
+
+<p>This contains information about how to interpret the data within an MNX document.</p>
+
+
+
+<h2>Keys:</h2>
+
+<table>
+<thead>
+<tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Required?</th>
+    <th>Description</th>
+</tr>
+</thead>
+
+
+<tr>
+    <td><nobr><b>"useAccidentalDisplay"</b></nobr></td>
+    <td>
+        
+        <a href="../boolean/">boolean object</a>
+        
+    </td>
+    <td>No</td>
+    <td>This answers the question "Does every note with a visible accidental have accidentalDisplay set?"<br><br>If this is set to true, then consuming applications should only draw an accidental on notes that have an "accidentalDisplay" value.<br><br>If this is set to false, then consuming applications should use their own algorithm to determine whether any given note's accidental should be drawn.<br><br>If this value is not provided, it is to be interpreted as false.</td>
+</tr>
+
+
+</table>
+
+
+
+
+
+<h2 id="examples">Examples</h2>
+
+<p>This object is used in the following examples:</p>
+<p>
+    <nobr><a href="../../examples/accidentals/">Accidentals</a></nobr>, <nobr><a href="../../examples/organ-layout/">Organ layout</a></nobr>
+</p>
+
+
+
+    </main>
+</div>
+
+
+<script type="text/javascript" src="../../../static/global.js"></script>
+
+</body>
+</html>

--- a/docs/mnx-schema.json
+++ b/docs/mnx-schema.json
@@ -804,6 +804,15 @@
     "mnx": {
       "additionalProperties": false,
       "properties": {
+        "support": {
+          "additionalProperties": false,
+          "properties": {
+            "useAccidentalDisplay": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
         "version": {
           "type": "integer"
         }


### PR DESCRIPTION
This adds an optional `"support"` object to the top-level `"mnx"` object. The goal of the `"support"` object is to provide information on how to interpret the current document. It's similar to MusicXML's [\<supports\> element](https://w3c.github.io/musicxml/musicxml-reference/elements/supports/).

At the moment, `"support"` includes a single optional key, `"useAccidentalDisplay"`. This tells consuming software whether notes include `"accidentalDisplay"` keys. It answers the question "Does every note with a visible accidental have `"accidentalDisplay"` set?"

If this is set to true, then consuming applications should only draw an accidental on notes that have an `"accidentalDisplay"` value.

If this is set to false, then consuming applications should use their own algorithm to determine whether any given note's accidental should be drawn.

If this value is not provided, it is to be interpreted as false.

The need for this feature arose in my work on the mnxconverter and the MNX viewer. In both cases, I realized there wasn't a clear way to know whether the lack of `"accidentalDisplay"` meant "don't draw the accidental" or "we haven't bothered to encode whether to draw the accidental."

This pull request includes the following changes:

* Added `"support"` and `"useAccidentalDisplay"` to the spec.
* Updated the note object's spec to say `"accidentalDisplay"` should only be used if `"useAccidentalDisplay"` is set to true.
* Updated two example documents to use `"useAccidentalDisplay"` (the two example documents that actually have rendered accidentals: "accidentals" and "organ-layout").

You can view the updated spec via this link:
https://cdn.githubraw.com/w3c/mnx/supports-accidental-display/docs/mnx-reference/objects/support/

I think everything is pretty straightforward here. I did make a few judgment calls:

* What happens when a document doesn't have `"useAccidentalDisplay": true` yet includes `"accidentalDisplay"` on note objects? I decided this should _not_ be allowed, just to avoid any ambiguity. Alternatively we could say "that's allowed, but behavior is undefined," but I'd like to avoid that.
* I called it `"support"` instead of `"supports"`. This way it's a noun instead of a verb.