### PR TITLE
Update examples to latest json

### DIFF
--- a/docs/static/examples/json/orchestral-layout.json
+++ b/docs/static/examples/json/orchestral-layout.json
@@ -2,19 +2,19 @@
 "mnx": {"version": 1},
   "global": {"measures": []},
   "parts": [
-    {"id": "Klar1"},
-    {"id": "Klar2"},
-    {"id": "Klar3"},
-    {"id": "Horn1"},
-    {"id": "Horn2"},
-    {"id": "Horn3"},
-    {"id": "Horn4"},
-    {"id": "Harfe", "staves": 2},
-    {"id": "Violin1"},
-    {"id": "Violin2"},
-    {"id": "Viola"},
-    {"id": "Cello"},
-    {"id": "Kontra"}
+    {"id": "Klar1", "measures": []},
+    {"id": "Klar2", "measures": []},
+    {"id": "Klar3", "measures": []},
+    {"id": "Horn1", "measures": []},
+    {"id": "Horn2", "measures": []},
+    {"id": "Horn3", "measures": []},
+    {"id": "Horn4", "measures": []},
+    {"id": "Harfe", "staves": 2, "measures": []},
+    {"id": "Violin1", "measures": []},
+    {"id": "Violin2", "measures": []},
+    {"id": "Viola", "measures": []},
+    {"id": "Cello", "measures": []},
+    {"id": "Kontra", "measures": []}
   ],
   "layouts": [
     {

--- a/docs/static/examples/json/system-layouts.json
+++ b/docs/static/examples/json/system-layouts.json
@@ -2,12 +2,12 @@
   "mnx": {"version": 1},
   "global": {"measures": []},
   "parts": [
-    {"name": "Flute 1", "id": "fl1", "shortName": "1"},
-    {"name": "Flute 2", "id": "fl2", "shortName": "2"},
-    {"name": "Flute 3", "id": "fl3", "shortName": "3"},
-    {"name": "Oboe 1", "id": "ob1", "shortName": "1"},
-    {"name": "Oboe 2", "id": "ob2", "shortName": "2"},
-    {"name": "Piano", "id": "piano", "staves": 2}
+    {"name": "Flute 1", "id": "fl1", "shortName": "1", "measures": []},
+    {"name": "Flute 2", "id": "fl2", "shortName": "2", "measures": []},
+    {"name": "Flute 3", "id": "fl3", "shortName": "3", "measures": []},
+    {"name": "Oboe 1", "id": "ob1", "shortName": "1", "measures": []},
+    {"name": "Oboe 2", "id": "ob2", "shortName": "2", "measures": []},
+    {"name": "Piano", "id": "piano", "staves": 2, "measures": []}
   ],
   "layouts": [
     {


### PR DESCRIPTION
This PR updates 2 example json files that now fail to validate against the schema. (This is because part.measures is now required.)

FWIW: my validator identifies a number of other issues with these files as well as the organ-layout file. References to non-existent measures, missing first clefs. That kind of thing. But this PR includes only those changes needed to get the files to validate against the schema.